### PR TITLE
Convert HTML markup to Markdown on BatID pages

### DIFF
--- a/programs/bat-id-2025-code-of-conduct.md
+++ b/programs/bat-id-2025-code-of-conduct.md
@@ -3,7 +3,7 @@ layout: noheader
 title: Code of Conduct - BatID 2025-International Symposium on the Infectious Diseases of Bats
 permalink: /programs/bat-id-2025/conduct
 ---
-This is the code of conduct for <a href="/programs/bat-id-2025">BatID 2025</a>.
+This is the code of conduct for [BatID 2025](/programs/bat-id-2025).
 
 # Code Of Conduct
 
@@ -13,7 +13,7 @@ Everyone participating in BatID 2025 is required to agree to the following Code 
 
 Anyone who violates our Code of Conduct may be removed from these spaces at the discretion of the BatID 2025 Organizing Committee.
 
-If you have questions about this policy, or suggestions for ways it might be improved, please contact us at <a href="mailto:batid2025@brooklab.org">batid2025@brooklab.org</a>.
+If you have questions about this policy, or suggestions for ways it might be improved, please contact us at [batid2025@brooklab.org](mailto:batid2025@brooklab.org).
 
 BatID 2025 is committed to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, mental illness, neurotype, physical appearance, body, age, race, ethnicity, nationality, language, or religion. We do not tolerate harassment of participants in any form.
 
@@ -37,7 +37,7 @@ If a participant engages in harassing behavior, BatID 2025 may take any action w
 
 ## Reporting and Enforcement
 
-If you are being harassed by a member of the BatID 2025 community, notice that someone else is being harassed, or have any other concerns related to this Code of Conduct, please contact us at <a href="mailto:batid2025@brooklab.org">batid2025@brooklab.org</a> (a distribution list which includes the BatID 2025 Organizing Committee: Dr. Cara Brook, Dr. Arinjay Banerjee, Dr. Daniel Becker, Dr. Hannah Frank, Dr. Stephanie Seifert) or reach out to a member of the Organizing Committee directly.
+If you are being harassed by a member of the BatID 2025 community, notice that someone else is being harassed, or have any other concerns related to this Code of Conduct, please contact us at [batid2025@brooklab.org](mailto:batid2025@brooklab.org) (a distribution list which includes the BatID 2025 Organizing Committee: Dr. Cara Brook, Dr. Arinjay Banerjee, Dr. Daniel Becker, Dr. Hannah Frank, Dr. Stephanie Seifert) or reach out to a member of the Organizing Committee directly.
 
 ## License
 

--- a/programs/bat-id-2025.md
+++ b/programs/bat-id-2025.md
@@ -23,122 +23,122 @@ Bats are the recognized reservoir host of several of the world's most high profi
 
 
 #### Wednesday, July 9, 2025
-<ul>
-<li> <strong>Conference registration</strong> will be open from <strong> 5-7 pm </strong> at the <a href="https://www.google.com/maps/place/1307+E+53rd+St,+Chicago,+IL+60615/@41.799341,-87.5972069,17z/data=!3m1!4b1!4m6!3m5!1s0x880e296bee15aceb:0x51a737579e5622b3!8m2!3d41.799337!4d-87.594632!16s%2Fg%2F11rg62wy11?entry=tts&g_ep=EgoyMDI1MDYxNy4wIPu8ASoASAFQAw%3D%3D&skid=7168e7bd-e286-4ec5-bbaf-c860106ffab6">picnic tables in Nichols Park</a>.</li>
-<li> Stop in to register, and grab some food or drink at nearby adjacent to the restaurant <a href="https://smallcheval.com/locations/hyde-park">Small Cheval</a> for an informal gathering before the meeting officially opens.</li>
-</ul>
+
+- <strong>Conference registration</strong> will be open from <strong> 5-7 pm </strong> at the [picnic tables in Nichols Park](https://www.google.com/maps/place/1307+E+53rd+St,+Chicago,+IL+60615/@41.799341,-87.5972069,17z/data=!3m1!4b1!4m6!3m5!1s0x880e296bee15aceb:0x51a737579e5622b3!8m2!3d41.799337!4d-87.594632!16s%2Fg%2F11rg62wy11?entry=tts&g_ep=EgoyMDI1MDYxNy4wIPu8ASoASAFQAw%3D%3D&skid=7168e7bd-e286-4ec5-bbaf-c860106ffab6).
+- Stop in to register, and grab some food or drink at nearby adjacent to the restaurant [Small Cheval](https://smallcheval.com/locations/hyde-park) for an informal gathering before the meeting officially opens.
+
 
 
 #### Thursday, July 10, 2025
 
-Location: <a href="https://maps.app.goo.gl/mG31rWwLbS1QTfwZ7"> Cloister Club, Ida Noyes Hall, The University of Chicago </a>
-<ul>
-<li> 7-8 am: Registration open </li>
-<li> Coffee and pastries provided </li>
-</ul>
+Location: [ Cloister Club, Ida Noyes Hall, The University of Chicago ](https://maps.app.goo.gl/mG31rWwLbS1QTfwZ7)
+
+- 7-8 am: Registration open 
+- Coffee and pastries provided 
+
 
 ##### Theme I: Bat immunology and within-host dynamics
 
-Session Chair: <a href="https://brooklab.org">Dr. Cara Brook</a>, University of Chicago<br />
-Plenary Speaker: <a href="https://lmdavalos.github.io">Dr. Liliana Davalos</a>, Stony Brook University<br />
+Session Chair: [Dr. Cara Brook](https://brooklab.org), University of Chicago<br />
+Plenary Speaker: [Dr. Liliana Davalos](https://lmdavalos.github.io), Stony Brook University<br />
 
 Additional Speakers:
-<ul>
-<li> Matae Ahn, LKC Medical School, Singapore </li>
-<li> Ken Field, Bucknell University </li>
-<li> Sarah van Tol, Rocky Mountain Labs, National Institutes of Health </li>
-<li> Arinjay Banerjee, Vaccine and Infectious Disease Organization (VIDO), University of Saskatchewan </li>
-<li> Peter Cresswell, Yale University </li>
-<li> Nolwenn Jouvenet, Institut Pasteur de Paris</li>
-<li> Hannah Frank, Tulane University </li>
-<li> Lea Gaucherand, CNRS, Université de Strasbourg </li>
-<li> Rita M. Quintela-Tizon, Department of Veterinary Microbiology, VIDO, University of Saskatchewan</li>
-<li> Daniel Becker, University of Oklahoma </li>
-<li> Lane Pierson, Case Western University </li>
-</ul>
+
+- Matae Ahn, LKC Medical School, Singapore 
+- Ken Field, Bucknell University 
+- Sarah van Tol, Rocky Mountain Labs, National Institutes of Health 
+- Arinjay Banerjee, Vaccine and Infectious Disease Organization (VIDO), University of Saskatchewan 
+- Peter Cresswell, Yale University 
+- Nolwenn Jouvenet, Institut Pasteur de Paris
+- Hannah Frank, Tulane University 
+- Lea Gaucherand, CNRS, Université de Strasbourg 
+- Rita M. Quintela-Tizon, Department of Veterinary Microbiology, VIDO, University of Saskatchewan
+- Daniel Becker, University of Oklahoma 
+- Lane Pierson, Case Western University 
+
 
 ##### Theme II: Bat pathogen evolution
 
-Session Chair:  <a href="https://banerjeelab.ca">Dr. Arinjay Banerjee</a>, VIDO, University of Saskatechwan<br />
-Plenary Speaker: <a href="https://leelabvirus.host/about">Dr. Benhur Lee</a>, Icahn School of Medicine at Mount Sinai<br />
+Session Chair:  [Dr. Arinjay Banerjee](https://banerjeelab.ca), VIDO, University of Saskatechwan<br />
+Plenary Speaker: [Dr. Benhur Lee](https://leelabvirus.host/about), Icahn School of Medicine at Mount Sinai<br />
 
 Additional Speakers:
-<ul>
-<li> Olivia Cords, UC Davis </li>
-<li> Luis Viquez-R, Bucknell University </li>
-<li> Phillida Charley, Colorado State University </li>
-<li> Hannah J. Eiseman, Tulane University </li>
-<li> Robert Cohen, Uniformed Services University of Health Sciences </li>
-<li> Nolwenn Jouvenet, Institut Pasteur de Paris</li>
-<li> Hannah Frank, Tulane University </li>
-<li> Annabel Anyang, University of Utah </li>
-</ul>
+
+- Olivia Cords, UC Davis 
+- Luis Viquez-R, Bucknell University 
+- Phillida Charley, Colorado State University 
+- Hannah J. Eiseman, Tulane University 
+- Robert Cohen, Uniformed Services University of Health Sciences 
+- Nolwenn Jouvenet, Institut Pasteur de Paris
+- Hannah Frank, Tulane University 
+- Annabel Anyang, University of Utah 
+
 
 
 ##### Poster Session
 
-<ul>
-<li> <em> All posters will need to fit on an easel that measures 40x32 inches. The easels can be oriented either vertically or horizontally, so you may choose to display your poster in whichever direction suits you best. </em> </li>  
-<li> 4:30-5:15 pm. <em> Odd number posters. </em> </li>
-<li> 5:15-6:00 pm. <em> Even number posters. </em> </li>
-<li> Drinks and hors d'oeuvres provided during poster session. Dinner to follow Thursday evening will be self-organized. See restaurant recommendations below. </li>
-</ul>
+
+- <em> All posters will need to fit on an easel that measures 40x32 inches. The easels can be oriented either vertically or horizontally, so you may choose to display your poster in whichever direction suits you best. </em>   
+- 4:30-5:15 pm. <em> Odd number posters. </em> 
+- 5:15-6:00 pm. <em> Even number posters. </em> 
+- Drinks and hors d'oeuvres provided during poster session. Dinner to follow Thursday evening will be self-organized. See restaurant recommendations below. 
+
 
 
 #### Friday, July 11, 2025
 
 ##### Theme III: Bat pathogen persistence and transmission dynamics
 
-Session Chair: <a href="http://beckerlab.weebly.com">Dr. Daniel Becker</a>, University of Oklahoma<br />
-Plenary Speaker: <a href="https://streickerlab.com">Dr. Daniel Streicker</a>, University of Glasgow <br />
+Session Chair: [Dr. Daniel Becker](http://beckerlab.weebly.com), University of Oklahoma<br />
+Plenary Speaker: [Dr. Daniel Streicker](https://streickerlab.com), University of Glasgow <br />
 Additional Speakers:
-<ul>
-<li> Gwen Kettenburg, University of Chicago </li>
-<li> Tamika Lunn, University of Georgia </li>
-<li> Vera C. Mols, Erasmus University Medical Center </li>
-<li> Kristian Forbes, University of Arkansas </li>
-<li> Jon Epstein, One Health Science </li>
-<li> Stephanie Seifert, Washington State University</li>
-<li> Benny Borremans, Wildlife Health Ecology Research Center </li>
-<li> Maya Weinberg, University of Essex  </li>
-<li> Sophia Horigan, University of Chicago  </li>
-<li> Johnny Uelmen, University of Wisconsin-Madisun  </li>
-</ul>
+
+- Gwen Kettenburg, University of Chicago 
+- Tamika Lunn, University of Georgia 
+- Vera C. Mols, Erasmus University Medical Center 
+- Kristian Forbes, University of Arkansas 
+- Jon Epstein, One Health Science 
+- Stephanie Seifert, Washington State University
+- Benny Borremans, Wildlife Health Ecology Research Center 
+- Maya Weinberg, University of Essex  
+- Sophia Horigan, University of Chicago  
+- Johnny Uelmen, University of Wisconsin-Madisun  
+
 
 ##### Theme IV: Bat pathogen discovery
 
-Session Chair: <a href="https://labs.wsu.edu/mezap/">Dr. Stephanie Seifert</a>, Washington State University <br />
-Plenary Speaker: <a href="https://anthonylab.vetmed.ucdavis.edu">Dr. Simon Anthony</a>, University of California-Davis <br />
+Session Chair: [Dr. Stephanie Seifert](https://labs.wsu.edu/mezap/), Washington State University <br />
+Plenary Speaker: [Dr. Simon Anthony](https://anthonylab.vetmed.ucdavis.edu), University of California-Davis <br />
 Additional Speakers:
 
-<ul>
-<li> Caleb Huntington, UC Davis </li>
-<li> Lexi E. Frank, University of Minnesota </li>
-<li> Maya Juman, Cambridge University  </li>
-<li> I-Ting Tu, University of Glasgow </li>
-</ul>
+
+- Caleb Huntington, UC Davis 
+- Lexi E. Frank, University of Minnesota 
+- Maya Juman, Cambridge University  
+- I-Ting Tu, University of Glasgow 
+
 
 
 ##### Theme V: Reconciling bat infectious diseases and conservation
 
-Session Chair: <a href="https://www.hkfrank.com">Dr. Hannah Frank</a>, Tulane University <br>
-Plenary Speaker: <a href="https://kingstonlab.org/people/tigga-kingston/">Dr. Tigga Kingston</a>, Texas Tech University<br />
+Session Chair: [Dr. Hannah Frank](https://www.hkfrank.com), Tulane University <br>
+Plenary Speaker: [Dr. Tigga Kingston](https://kingstonlab.org/people/tigga-kingston/), Texas Tech University<br />
 Additional Speakers:
 
-<ul>
-<li> AKM Dawlat Khan </li>
-<li> Abby Rutrough, Texas Tech University </li>
-<li> Kendra Phelps, University of Minnesota </li>
-<li> Benneth Obitte, Texas Tech University </li>
-<li> Natalie Wickenkamp, Colorado State University </li>
-</ul>
+
+- AKM Dawlat Khan 
+- Abby Rutrough, Texas Tech University 
+- Kendra Phelps, University of Minnesota 
+- Benneth Obitte, Texas Tech University 
+- Natalie Wickenkamp, Colorado State University 
+
 
 
 ##### Open Discussion
-<ul>
-<li> We will close the meeting with an Open Discussion of future priorities for the field and plans for a conference proceedings paper. </li>
-<li> 4:45 – 7:00 pm. Closing Social Hour at <a href="https://uofcpub.com">The Pub at Ida Noyes Hall.</a> <em> Food and drink available for purchase. </em> </li>
-</ul>
+
+- We will close the meeting with an Open Discussion of future priorities for the field and plans for a conference proceedings paper. 
+- 4:45 – 7:00 pm. Closing Social Hour at [The Pub at Ida Noyes Hall.](https://uofcpub.com) <em> Food and drink available for purchase. </em> 
+
 
 
 <hr />
@@ -147,31 +147,31 @@ Additional Speakers:
 Some recommended local restaurants that are unlikely to require reservations include: <br>
 
 <em> South of the Midway</em>
-<ul>
-<li> <a href="https://www.truthbetoldtavern.com">Truth Be Told</a> <br /> </li>
-<li> <a href="https://bardavid.uchicago.edu">Bar David</a> <br /> </li>
-</ul>
+
+- [Truth Be Told](https://www.truthbetoldtavern.com) <br /> 
+- [Bar David](https://bardavid.uchicago.edu) <br /> 
+
 
 <em> 57th Street</em>
-<ul>
-<li> <a href="https://www.truthbetoldtavern.com">Medici on 57th</a> <br /> </li>
-<li> <a href="https://bardavid.uchicago.edu">Noodles Etc</a> <br /> </li>
-</ul>
+
+- [Medici on 57th](https://www.truthbetoldtavern.com) <br /> 
+- [Noodles Etc](https://bardavid.uchicago.edu) <br /> 
+
 
 <em> 55th Street</em>
-<ul>
-<li> <a href="https://nellachicago.com">Nella Pizza e Pasta</a> <br /> </li>
-<li> <a href="https://www.nilehydepark.com">The Nile Hyde Park</a> <br /> </li>
-<li> <a href="https://chibarproject.com/reviews/woodlawntap/">Woodlawn Tap “Jimmy’s”</a> <br /> </li>
-</ul>
+
+- [Nella Pizza e Pasta](https://nellachicago.com) <br /> 
+- [The Nile Hyde Park](https://www.nilehydepark.com) <br /> 
+- [Woodlawn Tap “Jimmy’s”](https://chibarproject.com/reviews/woodlawntap/) <br /> 
+
 
 
 <em> 53rd Street</em>
-<ul>
-<li> <a href="https://giordanos.com/locations/hyde-park/">Giorodano’s Pizza</a> <br /> </li>
-<li> <a href="https://www.pizzacapri.com/hyde-park/">Pizza Capri</a> <br /> </li>
-<li> <a href="https://www.stringsramen.com">Strings Ramen</a> <br /> </li>
-</ul>
+
+- [Giorodano’s Pizza](https://giordanos.com/locations/hyde-park/) <br /> 
+- [Pizza Capri](https://www.pizzacapri.com/hyde-park/) <br /> 
+- [Strings Ramen](https://www.stringsramen.com) <br /> 
+
 
 
 <hr />
@@ -180,50 +180,50 @@ Some recommended local restaurants that are unlikely to require reservations inc
 
 Conference attendees who have not already booked dormitory lodging should book alternative lodging options independently.
 
-There are <strong>three hotels</strong> available in the Hyde Park, Chicago area, which can be accessed easily on foot from the University of Chicago: the <a href="https://sophyhotel.com/">Sophy</a>, the <a href="https://www.hyatt.com/hyatt-place/en-US/chizu-hyatt-place-chicago-south-university-medical-center">Hyatt Place Chicago-South</a>, and the <a href="https://www.thestudyatuniversityofchicago.com">Study</a>.
+There are <strong>three hotels</strong> available in the Hyde Park, Chicago area, which can be accessed easily on foot from the University of Chicago: the [Sophy](https://sophyhotel.com/), the [Hyatt Place Chicago-South](https://www.hyatt.com/hyatt-place/en-US/chizu-hyatt-place-chicago-south-university-medical-center), and the [Study](https://www.thestudyatuniversityofchicago.com).
 
-A variety of other hotel options are available in the Chicago Loop, which can be accessed easily from the University of Chicago via a 20-minute ride on the <a href="https://ridertools.metrarail.com">Metric Electric</a> lightrail (at the <a href="https://metra.com/train-lines/stations/55th-56th-57th-street">55th-56th-57th Street stop</a>).
+A variety of other hotel options are available in the Chicago Loop, which can be accessed easily from the University of Chicago via a 20-minute ride on the [Metric Electric](https://ridertools.metrarail.com) lightrail (at the [55th-56th-57th Street stop](https://metra.com/train-lines/stations/55th-56th-57th-street)).
 <br>
 #### ✈️ Travel
-Two international airports offer easy metro/lightrail access to the University of Chicago: <a href="https://www.flychicago.com/ohare/home/pages/default.aspx">O'Hare International Airport (ORD)</a> and <a href="https://www.flychicago.com/midway/home/pages/default.aspx">Midway International Airport (MDW)</a>.
+Two international airports offer easy metro/lightrail access to the University of Chicago: [O'Hare International Airport (ORD)](https://www.flychicago.com/ohare/home/pages/default.aspx) and [Midway International Airport (MDW)](https://www.flychicago.com/midway/home/pages/default.aspx).
 <br>
 <br>
 MDW is a little closer to UChicago and therefore our recommendation if you are able to find equivalent flight options to either airport.
 <br>
 <br>
-<strong>Getting here:</strong> The University of Chicago is easily accessible from both O'Hare (ORD) and Midway International Airports (MDW). You can take the Blue line (ORD) or Orange line (MDW) <a href= "https://www.transitchicago.com/assets/1/6/ctamap_Lsystem.png">"L"</a> to the Loop, then transfer to the <a href="https://metra.com/train-lines/me"> Metra Electric</a> at Millenium Station. From there, you can take the Metra direct to Hyde Park, getting off at either the <a href="https://metra.com/train-lines/stations/51st53rd-st-hyde-park">51st/53rd St. Hyde Park stop</a> or the <a href="https://metra.com/train-lines/stations/55th-56th-57th-street">55th-56th-57th Street stop</a> to walk to your lodging.
+<strong>Getting here:</strong> The University of Chicago is easily accessible from both O'Hare (ORD) and Midway International Airports (MDW). You can take the Blue line (ORD) or Orange line (MDW) ["L"](https://www.transitchicago.com/assets/1/6/ctamap_Lsystem.png) to the Loop, then transfer to the [ Metra Electric](https://metra.com/train-lines/me) at Millenium Station. From there, you can take the Metra direct to Hyde Park, getting off at either the [51st/53rd St. Hyde Park stop](https://metra.com/train-lines/stations/51st53rd-st-hyde-park) or the [55th-56th-57th Street stop](https://metra.com/train-lines/stations/55th-56th-57th-street) to walk to your lodging.
 
 #### 📝 Additional useful information
-<ul> 
-<li> <a href="https://www.google.com/maps/place/Hyde+Park,+Chicago,+IL/data=!4m2!3m1!1s0x880e2912ce6f7027:0xc0cfb5545d4a37b2?sa=X&ved=1t:242&ictx=111">Map of Hyde Park</a> </li>
-<li> <a href="https://bpb-us-w2.wpmucdn.com/voices.uchicago.edu/dist/7/4088/files/2025/01/UC_11x17-Print-Directory-Map_2024.pdf"> Map of University of Chicago </a> </li>
-<li> <a href="https://safety-security.uchicago.edu/transportation/driving-parking/visitor-parking"> University Parking Resources</a> </li>
-      <li> A variety of free street parking is also available adjacent to the university. Please see street signage for directions.</li>
-</ul>
+ 
+- [Map of Hyde Park](https://www.google.com/maps/place/Hyde+Park,+Chicago,+IL/data=!4m2!3m1!1s0x880e2912ce6f7027:0xc0cfb5545d4a37b2?sa=X&ved=1t:242&ictx=111) 
+- [ Map of University of Chicago ](https://bpb-us-w2.wpmucdn.com/voices.uchicago.edu/dist/7/4088/files/2025/01/UC_11x17-Print-Directory-Map_2024.pdf) 
+- [ University Parking Resources](https://safety-security.uchicago.edu/transportation/driving-parking/visitor-parking) 
+      - A variety of free street parking is also available adjacent to the university. Please see street signage for directions.
+
 
 
 <hr />
 
 Thanks to the support of our <strong>Advisory Committee</strong>:
-<ul>
-<li><a href="https://labs.vetmedbiosci.colostate.edu/schountz/">Dr. Tony Schountz</a>, Colorado State University</li>
-<li><a href="https://plowrightlab.org">Dr. Raina Plowright</a>, Cornell University</li>
-<li><a href="https://frick.eeb.ucsc.edu">Dr. Linfa Wang</a>, Duke-NUS</li>
-<li><a href="https://people.ucd.ie/emma.teeling">Dr. Emma Teeling</a>, University College Dublin</li>
-<li><a href="https://www.amnh.org/research/staff-directory/nancy-b-simmons">Dr. Nancy Simmons</a>, American Museum of Natural History</li>
-<li><a href="https://sites.google.com/view/aguilarlab/home">Dr. Hector Aguilar-Carreño</a>, Cornell University</li>
-</ul>
+
+- [Dr. Tony Schountz](https://labs.vetmedbiosci.colostate.edu/schountz/), Colorado State University
+- [Dr. Raina Plowright](https://plowrightlab.org), Cornell University
+- [Dr. Linfa Wang](https://frick.eeb.ucsc.edu), Duke-NUS
+- [Dr. Emma Teeling](https://people.ucd.ie/emma.teeling), University College Dublin
+- [Dr. Nancy Simmons](https://www.amnh.org/research/staff-directory/nancy-b-simmons), American Museum of Natural History
+- [Dr. Hector Aguilar-Carreño](https://sites.google.com/view/aguilarlab/home), Cornell University
+
 
 
 
 <!--
 
-<p style="font-size: 1.5em;"><strong><a href="https://airtable.com/appdHarZm5kC7Fkqf/pag1tw65yNV2QcS2a/form">Scholarship requests</a></strong> for registration fee waivers and travel support are due by February 28!</p> 
+<p style="font-size: 1.5em;"><strong>[Scholarship requests](https://airtable.com/appdHarZm5kC7Fkqf/pag1tw65yNV2QcS2a/form)</strong> for registration fee waivers and travel support are due by February 28!</p> 
 
 
 <div class="bs-callout bs-callout-info">
-<p style="font-size: 1.5em;"><strong><a href="https://ti.to/batid-2025/conference-registration">Conference registration</a></strong> is now open through April 15!</p> 
-<p style="font-size: 1.5em;"><strong><a href="https://ti.to/batid-2025/dormitory-lodging">Dormitory lodging</a></strong> is available to reserve through April 15!</p>
+<p style="font-size: 1.5em;"><strong>[Conference registration](https://ti.to/batid-2025/conference-registration)</strong> is now open through April 15!</p> 
+<p style="font-size: 1.5em;"><strong>[Dormitory lodging](https://ti.to/batid-2025/dormitory-lodging)</strong> is available to reserve through April 15!</p>
 <br />
 
 <p>This page last updated March 17, 2025.</p>
@@ -264,16 +264,16 @@ Registration for <strong>BatID 2025</strong> is now closed.
 
 <strong>February 24, 2025</strong>: Registration is open for BatID 2025! 
 <br />
-Register for a <strong>conference ticket <a href="https://ti.to/batid-2025/conference-registration">here</a> by April 15, 2025</strong>.<br />
+Register for a <strong>conference ticket [here](https://ti.to/batid-2025/conference-registration) by April 15, 2025</strong>.<br />
 
 
 <em>Registration fees are as follows:</em>
 
-<ul>
-<li>Faculty/Industry/Government Scientists/Media: $300</li>
-<li>Postdocs: $200</li>
-<li>Students (graduate and undergraduate): $150</li>
-</ul>
+
+- Faculty/Industry/Government Scientists/Media: $300
+- Postdocs: $200
+- Students (graduate and undergraduate): $150
+
 
 
 <div class="bs-callout bs-callout-info">


### PR DESCRIPTION
## Summary
- clean up `bat-id-2025` page by converting `<ul>` lists and `<a>` tags to markdown
- do the same for the BatID code-of-conduct page

## Testing
- `bundle exec jekyll build` *(fails: jekyll missing)*
- `bundle install` *(fails: network access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68588b20111c8327bcbbbd1c7e7761e7