### PR TITLE
Fix RSS link for external posts

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -13,7 +13,11 @@ layout: null
 		<title>{{ post.title | xml_escape }}</title>
 		<description>{{ post.content | xml_escape }}</description>
 		<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+		{% if post.link %}
+		<link>{{ post.link }}</link>
+		{% else %}
 		<link>{{ site.url }}{{ post.url }}</link>
+		{% endif %}
 		<guid isPermaLink="true">{% if post.link %}{{post.link}}{% else %}{{ site.url }}{{ post.url }}{% endif %}</guid>
 	  </item>
 	{% endfor %}


### PR DESCRIPTION
## Summary
- update RSS feed to output external link when `post.link` is present

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685954c6b82483278d6b54164f639eea