### PR TITLE
Add canonical redirects for link posts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,12 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
   <link rel="stylesheet" type="text/css" href="/assets/style.css" />
 
+{% if page.link %}
+  <meta http-equiv="refresh" content="0; url={{ page.link }}">
+  <link rel="canonical" href="{{ page.link }}">
+{% else %}
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
+{% endif %}
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }} RSS feed" href="{{ "/feed.xml" | relative_url }}">
 
   <meta property="og:site_name" content="{{ site.title }}" >
@@ -25,10 +30,10 @@
 {% endif %}
 {% if page.url %}
   <meta property="og:url" content="{{ site.url }}{{ page.url }}" >
-  <link rel="canonical" href="{{ site.url }}{{ page.url }}">
+  {% unless page.link %}<link rel="canonical" href="{{ site.url }}{{ page.url }}">{% endunless %}
 {% else %}
   <meta property="og:url" content="{{ site.url }}" >
-  <link rel="canonical" href="{{ site.url }}">
+  {% unless page.link %}<link rel="canonical" href="{{ site.url }}">{% endunless %}
 {% endif %}
 {% if page.description %}
   <meta name="description" content="{{ page.description }}" >

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,4 +16,8 @@ pagination:
   </div>
 </article>
 
+{% if page.link %}
+  <p><a class="external-link" href="{{ page.link }}">Original article</a></p>
+{% endif %}
+
 <a href="/news">Back to News</a>


### PR DESCRIPTION
## Summary
- add meta refresh and canonical tags for posts with `page.link`
- prevent duplicate canonical tags when `page.link` exists
- show an "Original article" link on post pages

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `jekyll -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685954d2ca3c8327a044e17b069de487