### PR TITLE
Fix circular logo display

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -84,6 +84,17 @@ https://gist.github.com/matthiasg/6153853
 .logo-circle {
   display: inline-block;
   padding: 1rem;
+  width: 200px;
+  height: 200px;
   border-radius: 50%;
+  overflow: hidden;
   background: radial-gradient(circle, #ffffff 0%, #f8f9fa 100%);
+}
+
+.logo-circle img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  border-radius: 50%;
 }

--- a/programs/bat-id-2025.md
+++ b/programs/bat-id-2025.md
@@ -8,7 +8,7 @@ permalink: /programs/bat-id-2025
 -->
 <center>
   <div class="logo-circle">
-    <img src="/programs/batid-img/BatIDlogo_bw_trimmed.png" alt="BatID 2025 logo" height="200px" />
+    <img src="/programs/batid-img/BatIDlogo_bw_trimmed.png" alt="BatID 2025 logo" />
   </div>
 </center>
 


### PR DESCRIPTION
## Summary
- fix CSS for circular logos
- remove hardcoded height attr from BatID page

## Testing
- `bundle exec jekyll build` *(fails: rbenv: version `3.1.4` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68631861d6cc8327843b16f7c98347fc