### PR TITLE
Add image alt attributes across site

### DIFF
--- a/_posts/2016-05-05-summary-of-old-natgeo.markdown
+++ b/_posts/2016-05-05-summary-of-old-natgeo.markdown
@@ -4,6 +4,7 @@ title: Cara blogged for National Geographic throughout her PhD. Read her doctora
 date: 2016-05-05 00:00:00 +0300
 description: # Add post description (optional)
 img: cara_chameleon.jpg # Add image post (optional)
+alt: Cara Brook with a chameleon during fieldwork.
 tags: [bats, disease ecology, conservation, Madagascar] # add tag
 link: https://blog.nationalgeographic.org/tag/cara-brook/
 sitemap: false

--- a/_posts/2018-02-13-it-always-starts-with-a-question-teaching-science-in-madagascar.markdown
+++ b/_posts/2018-02-13-it-always-starts-with-a-question-teaching-science-in-madagascar.markdown
@@ -4,6 +4,7 @@ title: Cara writes for NatGeo about teaching ecological modeling in Madagascar -
 date: 2018-02-13 00:00:00 +0300
 description:  # Add post description (optional)
 img: tsilavo-chameleon.jpg # Add image post (optional)
+alt: Tsilavo Rasolonjatovo holding a chameleon in Madagascar.
 tags: [disease ecology, teaching, madagascar] # add tag
 link: https://blog.nationalgeographic.org/2018/02/13/it-always-starts-with-a-question-teaching-science-in-madagascar/
 sitemap: false

--- a/_posts/2018-03-08-grantee-insights-why-fruit-bats-why-not.markdown
+++ b/_posts/2018-03-08-grantee-insights-why-fruit-bats-why-not.markdown
@@ -4,6 +4,7 @@ title: Cara describes the motivation for her work in Madagascar in a 'Grantee In
 date: 2018-03-08 00:00:00 +0300
 description:  # Add post description (optional)
 img: angavokely_nicolas.jpg # Add image post (optional)
+alt: Fieldwork scene at Angavokely, Madagascar.
 tags: [disease ecology, fruit bats, madagascar] # add tag
 link: https://blog.nationalgeographic.org/2018/03/08/grantee-insights-why-fruit-bats-why-not/
 sitemap: false

--- a/_posts/2019-04-16-disentangling-disease-transmission-in-madagascar-fruit-bats.markdown
+++ b/_posts/2019-04-16-disentangling-disease-transmission-in-madagascar-fruit-bats.markdown
@@ -4,6 +4,7 @@ title: Cara explains her new bat serology paper in a blog post with the Journal 
 date: 2019-04-16 01:00:00 +0300
 description:  # Add post description (optional)
 img: eidolon_JAE_blog.jpg # Add image post (optional)
+alt: Image from Journal of Animal Ecology blog about Eidolon bat research.
 tags: [fruit bat, disease ecology, madagascar] # add tag
 link: https://animalecologyinfocus.com/2019/04/16/disentangling-disease-transmission-in-madagascar-fruit-bats/
 sitemap: false

--- a/_posts/2019-11-21-pteropus-rufus-genome.markdown
+++ b/_posts/2019-11-21-pteropus-rufus-genome.markdown
@@ -4,6 +4,7 @@ title: Ekipa Fanihy releases first Madagascar fruit bat genome (Pteropus rufus) 
 date: 2019-11-21 01:00:00 +0300
 description:   
 img: cara_makira.JPG # Add image post (optional)
+alt: Cara Brook with collaborators in Makira, Madagascar.
 tags: [bats, zoonosis, COVID-19] # add tag
 link: https://www.dnazoo.org/post/on-the-island-of-madagascar-foxes-fly
 sitemap: false

--- a/_posts/2020-02-03-rousettus-madagascariensis-genome.markdown
+++ b/_posts/2020-02-03-rousettus-madagascariensis-genome.markdown
@@ -4,6 +4,7 @@ title: Ekipa Fanihy releases the Rousettus madagascariensis genome open-access w
 date: 2020-02-03 01:00:00 +0300
 description:  
 img: rousettus_madagascariensis.JPG # Add image post (optional)
+alt: Rousettus madagascariensis fruit bat.
 tags: [bats, genomics] # add tag
 link: https://www.dnazoo.org/post/rousette_bats_a_coronavirus_reservoir
 sitemap: false

--- a/_posts/2020-02-27-NSF-4-Awesome-Discoveries.markdown
+++ b/_posts/2020-02-27-NSF-4-Awesome-Discoveries.markdown
@@ -4,6 +4,7 @@ title: The NSF highlighted Cara's eLife paper in its weekly Video Series, '4 Awe
 date: 2020-02-27 01:00:00 +0300
 description: (optional)
 img: bat_cell_model.png # Add image post (optional)
+alt: Diagram of a bat cell infection model.
 tags: [bats, zoonosis, COVID-19] # add tag
 link: https://www.youtube.com/watch?v=y5_g_pjf0eE&feature=youtu.be
 sitemap: false

--- a/_posts/2020-03-27-who-what-why-podcast.markdown
+++ b/_posts/2020-03-27-who-what-why-podcast.markdown
@@ -4,6 +4,7 @@ title: Cara explains why bats are reservoirs for so many virulent viruses on the
 date: 2019-04-16 01:00:00 +0300
 description:  
 img: whowhatwhy.jpg # Add image post (optional)
+alt: WhoWhatWhy podcast logo.
 tags: [fruit bat, disease ecology, madagascar] # add tag
 link: https://animalecologyinfocus.com/2019/04/16/disentangling-disease-transmission-in-madagascar-fruit-bats/
 sitemap: false

--- a/_posts/2020-04-03-the-naked-scientists.markdown
+++ b/_posts/2020-04-03-the-naked-scientists.markdown
@@ -4,6 +4,7 @@ title: Cara discuses her recent eLife paper on 'The Naked Scientists' podcast
 date: 2020-05-15 01:00:00 +0300
 description:  # Add post description (optional)
 img: nakedscientists.png # Add image post (optional)
+alt: The Naked Scientists podcast logo.
 tags: [bats, zoonosis, COVID-19] # add tag
 link: https://www.thenakedscientists.com/articles/interviews/why-do-bats-carry-deadly-viruses
 sitemap: false

--- a/_posts/2020-05-15-bats-are-not-our-enemies.markdown
+++ b/_posts/2020-05-15-bats-are-not-our-enemies.markdown
@@ -4,6 +4,7 @@ title: Cara and colleagues explain how 'Bats Are Not Our Enemies' in a popsci ar
 date: 2020-05-15 01:00:00 +0300
 description:  # Add post description (optional)
 img: pteropus.jpg # Add image post (optional)
+alt: Photograph of a Pteropus (flying fox) bat.
 tags: [bats, zoonosis, conservation] # add tag
 link: https://blogs.scientificamerican.com/observations/bats-are-not-our-enemies/
 sitemap: false

--- a/_posts/2020-06-12-covid-conversations.markdown
+++ b/_posts/2020-06-12-covid-conversations.markdown
@@ -4,6 +4,7 @@ title: Cara discusses 'Virulent Viruses and Reservoir Hosts' in UC Berkeley's CO
 date: 2020-06-12 01:00:00 +0300
 description:  Dr. Cara Brook joins with UC Berkeley's Dr. Britt Glaunsinger to discuss coronavirus biology and bat reservoir dynamics in part with the university's COVID Conversations series# Add post description (optional)
 img: COVID-Conversations.jpg # Add image post (optional)
+alt: Poster for UC Berkeley’s COVID Conversations series.
 tags: [bats, zoonosis, COVID-19] # add tag
 link: https://news.berkeley.edu/2020/06/12/of-virulent-viruses-and-reservoir-hosts/
 sitemap: false

--- a/_posts/2020-06-14-bats-cnn.markdown
+++ b/_posts/2020-06-14-bats-cnn.markdown
@@ -4,6 +4,7 @@ title: Cara appears on CNN special with Anderson Cooper, 'Bats, The Mystery Behi
 date: 2020-06-14 01:00:00 +0300
 description:  (optional)
 img: bats-cnn.jpg # Add image post (optional)
+alt: Screenshot from CNN special ‘Bats: The Mystery Behind COVID-19.’
 tags: [bats, zoonosis, COVID-19] # add tag
 link: https://cnnpressroom.blogs.cnn.com/2020/06/09/cnn-to-air-special-on-the-connection-between-bats-and-covid-19/
 sitemap: false

--- a/_posts/2020-11-16-cara-loreal.markdown
+++ b/_posts/2020-11-16-cara-loreal.markdown
@@ -4,6 +4,7 @@ title: Cara is named a 2020 L'Oréal USA For Women in Science Fellow
 date: 2020-11-17 01:00:00 +0300
 description:  (optional)
 img: loreal-FWIS-2020.png # Add image post (optional)
+alt: L’Oréal USA For Women in Science 2020 logo.
 tags: [bats, Madagascar, women in science] # add tag
 link: https://www.aaas.org/news/loreal-usa-funds-research-and-outreach-activities-five-female-scientists
 sitemap: false

--- a/_posts/2020-12-01-meet-anecia.markdown
+++ b/_posts/2020-12-01-meet-anecia.markdown
@@ -4,6 +4,7 @@ title: Meet Anecia Gentles!
 date: 2020-12-01 01:00:00 -0700
 description:  (optional)
 img: anecia_gentles.jpg # Add image post (optional)
+alt: Portrait of Anecia Gentles.
 tags: [bats, Madagascar, women in science] # add tag
 permalink: /news/meet-anecia
 ---

--- a/_posts/2022-09-07-Novel-Henipavirus.markdown
+++ b/_posts/2022-09-07-Novel-Henipavirus.markdown
@@ -4,6 +4,7 @@ title: Novel henipavirus from the Malagasy fruit bat, Eidolon dupreanum!
 date: 2022-09-07 01:00:00 -0700
 description:  (optional)
 img: eidolon-dupreanum-duped.jpeg
+alt: Eidolon dupreanum fruit bat roost.
 tags: [Madagascar, fruit bats, viral discovery] # add tag
 permalink: /news/novel-henipavirus
 ---

--- a/_posts/2022-09-08-DP2-awarded.markdown
+++ b/_posts/2022-09-08-DP2-awarded.markdown
@@ -4,6 +4,7 @@ title: Brook lab wins NIH NIAID New Innovators Award (DP2)!
 date: 2022-09-08 01:00:00 -0700
 description:  (optional)
 img: NIAID.png
+alt: NIH NIAID logo.
 tags: [NIH, NIAID, grant] # add tag
 permalink: /news/nih-dp2
 ---

--- a/_posts/2023-05-16-Biota-award.markdown
+++ b/_posts/2023-05-16-Biota-award.markdown
@@ -4,6 +4,7 @@ title: Cara wins Biota award for conservation-related research!
 date: 2023-05-16 01:00:00 -0700
 description:  (optional)
 img: Spotlight-BiotaAwards.jpg
+alt: Banner for the Walder Foundation Biota Awards.
 tags: [Walder Foundation, Biota Awards, grant] # add tag
 permalink: /news/Biota
 ---

--- a/_posts/2023-09-09-Bat-Virulence.markdown
+++ b/_posts/2023-09-09-Bat-Virulence.markdown
@@ -4,6 +4,7 @@ title: New paper offers a mechanism for the extreme virulence of bat virus zoono
 date: 2023-09-09 01:00:00 -0700
 description:  (optional)
 img: Brook2023PLoSBio.jpg
+alt: Cover image from Brook et al. 2023 PLoS Biology article.
 tags: [bat, virus, virulence, tradeoff theory] # add tag
 permalink: /news/bat-virus-virulence
 ---

--- a/_posts/2023-10-01-bat-virscan.markdown
+++ b/_posts/2023-10-01-bat-virscan.markdown
@@ -4,6 +4,7 @@ title: Emily publishes first application of VirScan technology to identify virus
 date: 2023-10-01 01:00:00 -0700
 description:  (optional)
 img: bat-virscan.jpg
+alt: Graphic illustrating the bat VirScan antibody study.
 tags: [bat, virus, virscan] # add tag
 permalink: /news/bat-virscan
 ---

--- a/_posts/2023-11-24-bat-talk-vox.markdown
+++ b/_posts/2023-11-24-bat-talk-vox.markdown
@@ -4,6 +4,7 @@ title: Cara goes on camera with Vox Science to talk bat physiology and its conse
 date: 2023-11-24 01:00:00 -0700
 description:  (optional)
 img: vox-icon.png
+alt: Vox Science Explained icon.
 tags: [bat, virus] # add tag
 permalink: /news/bat-talk-vox
 ---

--- a/_posts/2024-06-20-C4C-video.markdown
+++ b/_posts/2024-06-20-C4C-video.markdown
@@ -4,6 +4,7 @@ title: Coding for Conservation program concludes first round of funding. Watch o
 date: 2024-06-20 01:00:00 -0700
 description:  (optional)
 img: C4Clogo.jpeg
+alt: Coding for Conservation program logo.
 tags: [conservation, education, programming] # add tag
 permalink: /news/C4C-year1
 ---

--- a/_posts/2024-07-03-ASM-talk.markdown
+++ b/_posts/2024-07-03-ASM-talk.markdown
@@ -4,6 +4,7 @@ title: Cara speaks at ASM Microbe 2024!
 date: 2024-07-03 01:00:00 -0700
 description:  (optional)
 img: ASMlogo.jpg
+alt: American Society for Microbiology logo.
 tags: [ASM, conference] # add tag
 permalink: /news/ASM-Microbe-2024
 ---

--- a/_posts/2025-01-21-a-day-in-the-life.markdown
+++ b/_posts/2025-01-21-a-day-in-the-life.markdown
@@ -4,6 +4,7 @@ title: A Day in the Life of a Field Project Manager
 date: 2025-01-21 01:00:00 -0700
 description:  (optional)
 img: katherine_pteropus.jpg
+alt: Field team member Katherine McFerrin holding a Madagascar flying fox.
 tags: [Madagascar, bat, education] # add tag
 permalink: /news/day-in-the-life
 ---

--- a/index.md
+++ b/index.md
@@ -10,4 +10,4 @@ title: "Brook Lab at the University of Chicago"
 
 The Brook Lab in the <a href="https://ecologyandevolution.uchicago.edu/">Department of Ecology and Evolution</a> at the <a href="https://uchicago.edu">University of Chicago</a> works at the interface of disease ecology, conservation biology, and public health to study the dynamics of zoonotic infections--pathogens transmitted from wildlife to human hosts.
 
-<img src="/assets/mada-bridge.jpg" class="img-fluid" />
+<img src="/assets/mada-bridge.jpg" class="img-fluid" alt="Wooden footbridge at a Madagascar field site." />

--- a/news.md
+++ b/news.md
@@ -9,7 +9,7 @@ permalink: /news
 <article class="post">
   <div class="post-image" class="float-start col-md-3">
     <a class="post-thumbnail" href="{% if post.link %}{{post.link}}{% else %}{{ post.url| prepend: site.baseurl}}{% endif %}">
-      <img src="{{"/assets/img/" | prepend: site.baseurl | append : post.img}}" class="img-fluid" />
+      <img src="{{"/assets/img/" | prepend: site.baseurl | append : post.img}}" class="img-fluid" alt="{{ post.alt | default: post.title }}" />
     </a>
   </div>
   <div class="post-content" style="float:left; margin-left:2em; max-width:500px;">


### PR DESCRIPTION
## Summary
- describe Madagascar bridge image on homepage
- surface alt text for post thumbnails in `news.md`
- add alt text metadata to each news post

## Testing
- `bundle install` *(fails: rbenv version `3.1.4` is not installed)*
- `bundle exec jekyll build` *(fails: rbenv version `3.1.4` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68681c71c2948327ad19f2242cc311fd