### PR TITLE
Replace HTML line breaks with Markdown

### DIFF
--- a/_posts/2020-12-01-meet-anecia.markdown
+++ b/_posts/2020-12-01-meet-anecia.markdown
@@ -12,6 +12,6 @@ permalink: /news/meet-anecia
 
 Hey! I’m Anecia Gentles, and I’m a graduate student at the University of Georgia in the IDEAS ( [Integrative Disease Ecology Across Scales](https://ideas.ecology.uga.edu/)) program. I joined Ekipa Fanihy in January 2019 as a field team manager – dipping my toes into disease ecology and long-term fieldwork all at once. My interests shifted to disease ecology after working on a project that described the ecosystem function of lemur-mediated seed dispersal with my undergraduate advisor [Dr. Amy Dunham](https://amydunham.weebly.com/) of Rice University. I realized that conservation efforts benefit all of Earth’s inhabitants, and the importance of striking the balance between these goals and human needs becomes more and more apparent with each passing year. For that reason, I intend to study the various ways that human land use can affect the behavior of pathogen hosts – particularly bats.
 
-<br />
+
 
 As a newly minted graduate student, I am beyond grateful for the growth and experience I gained throughout my tumultuous undergraduate career, as a barista unsure that I would ever make it to this stage, and finally, as a part of Ekipa Fanihy. For POC undergraduates and high school students who may stumble across this page, I am always available by email for questions about the glamours and pitfalls of this journey. See [here](https://brooklab.org/news/2020-12-02-ag-post) for a blog post summarizing my recent [bat virus model review paper](https://www.tandfonline.com/doi/full/10.1080/20477724.2020.1833161) with Ekipa Fanihy!

--- a/_posts/2020-12-02-anecia-paper.markdown
+++ b/_posts/2020-12-02-anecia-paper.markdown
@@ -11,11 +11,11 @@ permalink: /news/anecia-review-paper
 
 by Anecia Gentles
 
-<br />
+
 
 If [my new paper](https://doi.org/10.1080/20477724.2020.1833161) made you feel like this...
 
-<br />
+
 
 <img src="/assets/img/anecia-logo-bat-model-review.png" alt="anecia-logo" class="img-left-w-text" />
 
@@ -48,7 +48,7 @@ Disease ecologists also use the SIR model to understand transmission dynamics in
 
 The available literature focuses on three lyssaviruses in several bat species: rabies virus (RABV) in North American big brown bats (Eptesicus fuscus) and Peruvian vampire bats (Desmodus rotundus); European bat lyssavirus type 1 (EBLV-1) in four insectivorous bat species in Spain; and Lagos Bat Virus (LBV) in African straw-colored fruit bats (Eidolon helvum). Broadly, bat-lyssaviruses can be represented by an ‘SEIR’ model framework – in which ‘E’ stands for the ‘Exposed’ class. Generally, the RABV studies that we reviewed agree that bats will either die or seroconvert (test positive for RABV antibodies) after exposure to an infected individual, and repeated exposure may lead to immunity. These variations in response to exposure may play a large part in maintaining rabies virus in bat populations. Bats exposed or infected with EBLV-1 or LBV also show similar dynamics, though migratory behavior and co-roosting amongst the Spaniard bat species appears to play a role in maintaining EBLV-1, and African straw-colored fruit bats may become immune for life after surviving an LBV infection.
 
-<br/>
+
 
 <div style="clear:both;">&nbsp;</div>
 
@@ -65,7 +65,7 @@ The available literature focuses on three lyssaviruses in several bat species: r
 
 Filoviruses infamously include the genera Marburgvirus and Ebolavirus, both of which are believed to be maintained in bat reservoirs. Of the seven mechanistic models of bat-filovirus systems that we reviewed, only one (by Ekipa Fanihy!) was fitted to data. This study fitted an ‘MSIRN’ model to age-structured serological data collected from Madagascan flying foxes (Pteropus rufus). Here, the M stands for ‘Maternally-derived immunity’ – a process by which newborn bats receive antibodies from their mothers, and ‘N’ (non-antibody mediated immune) represents a class of individuals who maintained lifelong immunity not detectable by an antibody response. The model proposes an explanation for the age-structured serological data, hypothesizing that cell-mediated or innate immunity may play a role in bat filovirus maintenance. The low force of infection (or per capita rate at which individuals become infected) estimated for this flying fox population suggests that spatial metapopulation dynamics, in which infections blink in and out of local populations, may play a role in virus maintenance in this system.
 
-<br/>
+
 
 <div style="clear:both;">&nbsp;</div>
 
@@ -82,7 +82,7 @@ Image from Santino Andry, 2019.
 
 Bats infected with henipaviruses shed virus in their urine. This allows researchers to noninvasively collect urine samples beneath roosts. Two of the three focal studies of this section modeled transmission of Ghanaian henipavirus (GhV) collected from E. helvum bats sampled from populations across Africa, and from a captive colony in Ghana. The third study, by Ekipa Fanihy, modeled an undescribed henipavirus identified serologically in the Madagascan fruit bat, Eidolon dupreanum.  The pan-African and Malagasy studies came to similar conclusions, showing an important role for waning immunity in explaining patterns in the henipavirus data, though MSIRS model offered the best match to the GhV data while another MSIRN model recovered the Malagasy henipavirus data. 
 
-<br />
+
 
 <div style="clear:both;">&nbsp;</div>
 
@@ -98,7 +98,7 @@ Bats infected with henipaviruses shed virus in their urine. This allows research
 
 At the time of the writing of our paper, we found only one data-fitted model of a coronavirus system! The authors of this study found that an SIRS model that allows some bats to maintain a long (‘persistent’) infectious period best fit the transmission dynamics of an undescribed alphacoronavirus in the large-footed myotis bats (Myotis macropus) of Australia.  Given our current situation, many more models of coronavirus dynamics in bat systems are likely to emerge in the upcoming years!
 
-<br/>
+
 
 <div style="clear:both;">&nbsp;</div>
 

--- a/_posts/2020-12-15-meet-fifi.markdown
+++ b/_posts/2020-12-15-meet-fifi.markdown
@@ -11,22 +11,22 @@ permalink: /news/meet-fifi
 
 Hi! I am Fifi Ravelomanantsoa, and I am one of the members of Ekipa Fanihy.
 
-<br />
+
 
 In 2016, after having obtained my master's degree by carrying out research on models of the biodiversity of bats in the Melaky region in the West of Madagascar, I thought of continuing my studies by channeling my research into the ecology of zoonoses in Malagasy fruit bats. These ideas come from the fact that these endemic bats play an important role in seed disperal and pollination but also contribute to the transmission of emerging diseases. Therefore, I then looked for opportunities to carry out this research. A lot of obstacles were put in my way and I almost gave up on science. In the meantime, I was carrying out field studies doing assistance and consultancy work.
 
-<br />
+
 
 In early 2019, my classmate and I were discussing our research and studies, and he told me about Ekipa Fanihy: Cara Brook was looking for a student who could join her fruit bat team and carry out doctoral studies. My friend then put me in touch with Cara and she agreed to make me a part of the team. Being a member of Ekipa Fanihy is important to me because, firstly, the studies carried out by the team really coincide with the studies I have always wanted to do. Second, thanks to Ekipa Fanihy, I have been able to establish relationships with other researchers, which is beneficial for me since I am a shy type of person. And thirdly, thanks to this team, I have been able to gain new experiences that I have never had the opportunity to pursue before.
 
-<br />
+
 
 Bats play an important role in maintaining ecosystem balance by participating in forest regeneration and regulating the populations of insect vectors of disease. But their flexibility in occupying many ecological niches, as well as their tendency to form large colonies, makes them powerful transmitters of disease. This contradiction has prompted me to focus my doctoral research on both the roles of fruit bats in seed dispersal and pollination in Madagascar, as well as seasonal variations in the intestinal flora of these bats' microbiomes and their interactions with the dynamics of viral and bacterial infections. These studies will both quantify the ecosystem services offered by these bats, as well as identify and mitigate the zoonotic diseases that they host. This work is particularly important for countries like Madagascar where deforestation has increased in recent years and where disease management is often neglected.
 
-<br />
+
 
 Currently, I am continuing my studies in the field of wildlife conservation at the University of Antananarivo. I am planning to make my first registration as a doctoral student in the upcoming academic year. I also intend to apply and try my luck for sandwich fellowships so that I can gain new knowledge and academic experiences in universities abroad. There is still a long way to go and this is only the beginning of my career as a researcher.
 
-<br />
+
 
 See [here](https://brooklab.org/news/2020-12-16-FR-post) for a blog post summarizing my recent [bat-borne coronavirus review paper](https://doi.org/10.1042/ETLS20200097) with Ekipa Fanihy!

--- a/_posts/2020-12-16-fifi-CoV-paper.markdown
+++ b/_posts/2020-12-16-fifi-CoV-paper.markdown
@@ -11,7 +11,7 @@ permalink: /news/fifi-coronavirus-review
 
 by Fifi Ravelomanantsoa
 
-<br/>
+
 
 Wondering how coronaviruses made it from bats to humans?
 
@@ -21,29 +21,29 @@ Wondering how coronaviruses made it from bats to humans?
 
 Then this blog digest of [our recent paper](https://doi.org/10.1042/ETLS20200097) is made for you!
 
-<br />
+
 
 Coronaviruses are RNA viruses notorious for their ability to switch host species—for example, to transmit from bat to human. Bats are the original source hosts for all Alpha- and Betacoronaviruses, including five of the seven coronaviruses known to infect humans: HCoV-229E, HCoV-NL63 (which cause the common cold), as well as the more deadly SARS-CoV, MERS-CoV, and SARS-CoV-2.
 
-<br />
+
 
 To “host-switch”, a virus must, first, enter the cells of a new host, and second, adapt to this new host environment. CoVs are uniquely well-suited to entering the cells of many mammals due to their flexible use of a variety of host cell surface receptors that are found on the cells of many species. For example, HCoV-229E uses the hAPN cellular receptor to enter human cells, while HCoV- NL63 uses angiotensin converting esterase (ACE2), and MERS-CoV uses dipeptidyl peptidase 4 (DPP4). All of these cell surface receptors can be found on the cells of many mammalian species—meaning that a virus capable of using these receptors in one host (i.e. bats) will be well-poised to transmit to other mammal hosts, too. Indeed, scientists believe that SARS-CoV-2-like viruses circulating in wild bats needed very few new adaptations (if any) to be able to transmit among human hosts.
 
-<br />
+
 
 Once entered into a host cell, CoVs also demonstrate remarkable adaptive capacity, resulting from their rapid mutation rates (as are common to all RNA viruses), as well as their large genome sizes and propensity for homologous recombination (traits specific to coronaviruses). CoVs are able to maintain large genomes because they encode a proofreading capacity in the RNA polymerase that they use to replicate, which helps them avoid accumulating large quantities of deleterious mutational errors. In turn, having larger genomes means that these viruses have more genetic material available for recombination—or the exchange of gene fragments between two viruses in the same cell. Recombination events help viruses switch hosts by allowing viruses to make large genetic changes very rapidly.
 
-<br />
+
 
 Among coronaviruses, the Sarbecovirus subgenus (belonging to the Betacoronavirus genus) poses a particularly dangerous pandemic threat, as has been already realized in the case of SARS-CoV and SARS-CoV-2, which fall within this clade. Sarbecoviruses are typically hosted by the Rhinolophidae horseshoe bats of Asia, Africa and Europe, including the two most closely related viruses to SARS-CoV-2, which have been previously described in Rhinolophus afﬁnis and Rhinolophus malayanus. Many genetically distinct Sarbecoviruses are known to circulent in several species of Chinese horseshoe bat that all reside in the same cave systems, thus facilitating what is known as “superinfection”, or one host’s infection with multiple different viruses at once. Bat superinfection with multiple Sarbecoviruses in turn facilitates the recombination events that allow this clade to make sudden and dramatic host shifts.
 
-<br />
+
 
 Most Sarbecoviruses that have been previously described are found in Asia, though recent work indicates that these viruses do circulate in Africa and Europe. The extent to which novel Sarbecoviruses are capable of invading human cells has not been thoroughly studied. More extensive longitudinal surveillance of coronaviruses in their native bat species, including more widespread sampling in understudied regions—like Africa (and including Madagascar!)—will be important for preventing the emergence of additional coronavirus zoonoses in the future. Much work lies ahead for Ekipa Fanihy!
 
 Also, this paper made the cover of 'Emerging Topics in Life Sciences'! Thanks to Nikhil Deshmukh for the photo.
 
-<br/>
+
 
 <img src="/assets/img/m_etls_4_4.cover.png" alt="paper-cover" class="img-left-w-text" />
 

--- a/_posts/2021-01-11-meet-angelo.markdown
+++ b/_posts/2021-01-11-meet-angelo.markdown
@@ -11,10 +11,10 @@ permalink: /news/meet-angelo
 
 Hello, I am Angelo Andianiaina, one of the members of Ekipa Fanihy. I am PhD student at the Department of Zoology and Animal Biodiversity of the University of Antananarivo, Madagascar and  a graduate of the University of Antananarivo in Animal Conservation. I have previously worked on projects to promote lemur conservation in northern and eastern Madagascar, as well as on projects to document the biodiversity and herpetology of small mammals in the east part of Madagascar. What people told me was that working with fruit bats would be a challenge, so I felt inspired to take up this challenge.
 
-<br />
+
 
 When Ekipa Fanihy was looking for a student back in 2018, the project was directly in my interest, and I was excited to join. I was fascinated by the potential effect of that the ectoparasites--called bat flies--which live on the fruit bats' fur might have on bat health. I therefore decided to undertake PhD research studying the seasonal variation of ectoparasitic infestation in two Malagasy fruit bats (<i>Eidolon dupreanum</i> and <i>Rousettus madagascariensis</i>) and the impacts of this variation on the dynamics of infection for vector-borne pathogens such as <i>Bartonella</i> spp., under the direction of Cara and Aristide Andrianarimisa. This project has at least three main aims: first, to help bat conservation; second, to mitigate potential impacts of infection; and third, to improve knowledge of the ecology and biology of bat ectoparasites. Joining Ekipa Fanihy has been very important for helping me to develop this project and grow as a researcher.
 
-<br />
+
 
 <b>Ekipa Fanihy is for me a family, where I am like a "Zandry" (which means little brother in our native Malagasy) and a "Zoky" (big brother) at the same time.</b>

--- a/_posts/2021-04-13-meet-santino-andry.markdown
+++ b/_posts/2021-04-13-meet-santino-andry.markdown
@@ -11,18 +11,18 @@ permalink: /news/santino-reflects-on-covid-in-madagascar
 
 Salama, I’m Santino Andry. I study entomology at the University of Antananarivo, though I am currently locked down at home in the COVID-19 pandemic. Madagascar is now facing a surge of cases and deaths beyond that seen in 2020. This time is hard for everyone because COVID causes both disease and economic hardship. Restrictions and lockdowns are hurting for all of us because we are deprived of liberty but those are the best tools we have to slow the spread of COVID-19 before vaccines make it to Madagascar. We have to stand together. Protect yourself and protect people around you by wearing a mask, washing hands frequently, and social distancing. According to Malagasy saying, <i>lahy tokana ny aina</i>: we only have one life.
 
-<br />
+
 
 Before the pandemic, I used to travel with Ekipa Fanihy to catch bats every month for our project. I met members of Ekipa Fanihy for the first time in January 2019 during the annual workshop for learning about models (E<sup>2</sup>M<sup>2</sup>) and joined the team as a volunteer and then a graduate student. This Ekipa means a lot to me because the members always show solidarity. Besides sharing scientific knowledge, the Ekipa also shares their cares. These days, we do this every week on zoom.
 
-<br />
+
 
 My research topic on the team is about the ectoparasites of the fruit bats. I decided to learn about ectoparasites because they may be vectors of the bat pathogens that cause zoonosis. So it is essential to figure out their biology and ecology in order to understand the mechanism of potential zoonosis. Also, as an entomologist, I really love to work on tiny animals because they interact with us every day and have an important role in both ecosystem ecology services and public health.
 
-<br />
+
 
 I hope things get better soon.
 
-<br />
+
 
 Visit [covid19mg.org](https://www.covid19mg.org/dashboard_EN.html) to learn more about COVID-19 in Madagascar.

--- a/_posts/2021-04-18-covid-refelctions-from-fifi.markdown
+++ b/_posts/2021-04-18-covid-refelctions-from-fifi.markdown
@@ -11,15 +11,15 @@ permalink: /news/covid-in-madagascar
 
 I remember the day of March 19, 2020. Angelo and I were in Ambakoana for our monthly data collection when the President of the Republic of Madagascar announced that the virus agent of the Covid19 pandemic was present in the Malagasy territory. We were afraid because according to the speech, the people who tested positive were tourist guides who had come to stay in a Hotel in Moramanga after epidemiological monitoring. According to our calculation, it was the day that Angelo and I were shopping in Moramanga for the fieldwork. Therefore, once we arrived in Tana, we decided to take a test and happily it was negative. On our way back, the roads were very quiet, few cars were driving and few people were out. We were locked down for about six months or so. It was the first wave.
 
-<br />
+
 
 A year later, on March 20, 2021, we were told that the new variant from South Africa is present in Madagascar and that the latter is more serious than the old one. Currently, Antananarivo is experiencing its second wave of pandemic. In comparison to the first, many people are infected and are gravely ill; the deaths keep increasing every day. We are starting to panic because many of our friends and acquaintances are affected and some are already dead. Almost every day we hear bad news in our neighborhood. Faced with this situation, we do our best not to be contaminated (me and my family for example, we use certain essential oils made from Malagasy medicinal plants apart from wearing a mask and social distancing when we are forced to go outside the house). Despite this, some people still don't wear masks and still gather in groups. But my biggest concern is that our country does not have enough supplies to face the pandemic: hospitals and treatment centers are full, oxygen is not sufficient, and the price for it is climbing from 1,200,000 Ar up to 5,000,000 Ariary. Drugs are also quite expensive when you have to buy them. This is very hard for many Malagasy people.
 
-<br />
+
 
 This pandemic reminds me of the importance of family and friends and that human life can be fragile.
 
-<br />
+
 
 <font size="2">
 <i>(<a href="https://www.jeuneafrique.com/1149861/politique/covid-a-madagascar-la-guerre-de-loxygene/">Image</a> copyright RIJASOLO/AFP, from the hospital of Andohatapenaka, in Antananarivo, July 20, 2020)</i>

--- a/_posts/2022-02-07-nobecoviruses-no-better-time-to-learn-from-gwen.markdown
+++ b/_posts/2022-02-07-nobecoviruses-no-better-time-to-learn-from-gwen.markdown
@@ -14,22 +14,22 @@ By Gwen Kettenburg
 
 Looking for new descriptions of emerging bat coronaviruses in underexplored areas? Then check out our [new paper](https://www.frontiersin.org/articles/10.3389/fpubh.2022.786060/abstract), and read our short description below. 
 
-<br />
+
 
 Coronaviruses are on everyone’s mind lately with the COVID-19 pandemic still raging. They are RNA viruses that traditionally have the ability to switch host species (bats to humans, or bats to an intermediate species then to humans). There are Alphacoronaviruses (some found in bats, as well as the well-known human coronavirus, NL63—which also originated in bats!), Deltacoronaviruses (found mostly in birds), Gammacoronaviruses (also mostly found in birds) and Betacoronaviruses (well characterized in bats). Betacoronaviruses have been the causative agent of more recent pandemics: SARS-CoV, and now SARS-CoV-2. These two pandemic viruses belong to a subgroup of Betacoronaviruses called Sarbecoviruses, but other less characterized groups exist. 
 
-<br />
+
 
 Since the origins of the first SARS-CoV epidemic, there have been many efforts to find bat CoVs circulating in their natural hosts in Asia, and, recently, there has been a push to survey African bat populations as well—but these studies are still limited. After SARS-CoV and SARS-CoV-2, efforts were amplified to find more Sarbecoviruses but less attention was paid to other groups. Nobecoviruses is another Betacoronavirus subgenus in which all discovered viruses to date have been found in fruit bats in the family Pteropodidae. Some Nobecoviruses have been found in African bat populations, and others have originated in Asian bat populations and shown an interesting potential to recombine with orthoreoviruses. We found three novel Nobecovirus sequences, two in Rousettus madagascariensis and one in Pteropus rufus. 
 
-<br />
+
 
 Madagascar is home to bats that originally evolved in both Africa and Asia, and in fact some African bat species, co-roost with endemic Malagasy bat species. The phylogenetic histories of our novel sequences reflect these unique divergent bat histories, with the virus we identified from P. rufus in fact ancestral to all currently described Nobecoviruses. As Madagascar is a unique island location with a long history of separation from other land masses, it hosts unique flora and fauna—and viral assemblages. Because local human populations in Madagascar hunt and consume bats for food, it is important to continue this work in describing novel viruses to prevent potential spillovers. 
 
-<br />
+
 
 More work lies ahead for Ekipa Fanihy—‘Team Fruit Bat’ in Malagasy—and we will continue to survey more Malagasy bats for more emerging viruses. Check back in the upcoming months for exciting updates as our new lab takes flight!
 
-<br />
+
 
 

--- a/_posts/2022-02-20-role-of-gastrointestinal-microbiomes-in-bats-from-fifi.markdown
+++ b/_posts/2022-02-20-role-of-gastrointestinal-microbiomes-in-bats-from-fifi.markdown
@@ -7,7 +7,7 @@ img: 2022-02-20-FR-3.png # Add image post (optional)
 tags: [bats, microbiomes] # add tag
 permalink: /news/gastrointestinal-microbiomes
 ---
-<br />
+
 
 By Fifi Ravelomanantsoa
 
@@ -15,30 +15,34 @@ By Fifi Ravelomanantsoa
 
 
 
-<br />
+
 
 There are many ecosystem services that bats provide to biodiversity, such as pollination, seed dispersal and the consumption of insects that both act as disease vectors and agricultural pests. Bats are also known to be unique hosts of viruses that cause extraordinary pathology in humans. However, little is known about the effects of these viruses on bat health. 
 
-<br />
+
 
 In many mammals, gastrointestinal microbiomes (GIT)—or the bacteria, bacteriophages, fungi, protozoa, and viruses that inhabit the gut—are one of the main elements that influence health and disease. Mammalian microbiomes can both exclude potential pathogens from the host or facilitate pathogen persistence, improve host nutrition to facilitate disease resistance, influence host fitness and behavior, and help maintain homeostasis. The field of bat microbiome research is relatively new and suggests that bat microbiomes are unique from those of other mammals—and could influence their unique immunity. In our [new article](https://doi.org/10.1016/j.tim.2021.12.009), we review literature to date on this subject and speculate on the role of bat mircobiomes in immune functioning.
 
-<br />
+
 
 [<img src="/assets/img/2022-02-20-FR-2.png" alt="FR" class="img-fluid" />](https://www.shutterstock.com/image-vector/realistic-flat-vector-illustration-small-large-1305066094)
 
-<br/><br/>
+
+
+
 
 While human and mouse GIT microbiomes are largely dominated by the phyla, Bacterioidetes and Firmicutes, bat GITs are largely composed of Proteobacteria—which, intriguingly, are associated with dysbiosis and inflammation of the GIT in humans and mice. In this way, bat GITs more closely resemble the microbiomes of birds than those of other mammals. 
 
-<br />
+
 
 <img src="/assets/img/2022-02-20-FR-3.png" alt="FR" class="img-fluid" />
 
-<br/><br/>
+
+
+
 
 We amass evidence to suggest that Proteobacteria likely act mutualistically with bat hosts, hypothesizing that because bats (and birds) maintain short gut transit times—meaning that food passes quickly through their digestive tracts—to make themselves light for flight, only Proteobacteria are able to colonize the GIT fast enough to become resident microbiota. Proteobacteria likely play a similar role for bats that other microbiome phyla do for other mammals—however, most of these functions have yet to be described. Elucidating these functions is a major future research priority—including part of my plan for my PhD!
 
-<br />
+
 
 

--- a/_posts/2022-03-29-bats-host-virulent-viruses.markdown
+++ b/_posts/2022-03-29-bats-host-virulent-viruses.markdown
@@ -7,16 +7,16 @@ img: bat-virus-virulence.png
 tags: [bats, viruses] # add tag
 permalink: /news/bat-virus-virulence
 ---
-<br />
+
 
 <img src="/assets/img/bat-virus-virulence.png" alt="CB" class="float-start col-md-5" />
 
-<br />
+
 
 Cara's new paper with Sarah Guth from the [Boots lab](https://bootslab.org/) at UC Berkeley is out this week in PNAS! The clear need to mitigate zoonotic risk has fueled increased viral discovery in specific reservoir host taxa. We show that a combination of viral and reservoir traits can predict zoonotic virus virulence and transmissibility in humans, supporting the hypothesis that bats harbor exceptionally virulent zoonoses. However, pandemic prevention requires thinking beyond zoonotic capacity, virulence, and transmissibility to consider collective “burden” on human health. For this, viral discovery targeting specific reservoirs may be inefficient as death burden correlates with viral, not reservoir, traits, and depends on context-specific epidemiological dynamics across and beyond the human–animal interface. These findings suggest that longitudinal studies of viral dynamics in reservoir and spillover host populations may offer the most effective strategy for mitigating zoonotic risk.
 
 Read the full paper [here](https://doi.org/10.1073/pnas.2113628119)!
 
-<br />
+
 
 

--- a/_posts/2022-04-03-nextstrain-live.markdown
+++ b/_posts/2022-04-03-nextstrain-live.markdown
@@ -7,16 +7,16 @@ img: nextstrain-mada.png
 tags: [Madagascar, SARS-CoV-2] # add tag
 permalink: /news/SC2-Mada
 ---
-<br />
+
 
 <img src="/assets/img/nextstrain-mada.png" alt="SC2-mad" class="float-start col-md-5" />
 
-<br />
+
 
 Our [Nextstrain](https://nextstrain.org) community build for SARS-CoV-2 transmission in Madagascar is now live at the following [link](https://nextstrain.org/community/brooklabteam/ncov-Madagascar)! You can play with the build, experimenting with coloring the sequences by various metadata (e.g. country of origin, location, clade, date, etc) and watch videos of the spread of infection across the country in this auspice interface.
-<br> 
+
 Stay tuned for updates on our paper-in-progress and additions of more recent data!
 
-<br />
+
 
 

--- a/_posts/2022-08-30-J-Mammalogy.markdown
+++ b/_posts/2022-08-30-J-Mammalogy.markdown
@@ -11,39 +11,38 @@ permalink: /news/mada-bat-morphology
 
 By Santino Andry and Angelo Andrianiaina
 
-<br> 
-
 <img src="/assets/img/Pteropus_rufus.jpeg" alt="pteropus" class="float-start col-md-5" />
 
-<br />
+
 This post commemorates the publication of our new paper, ['Reproduction, seasonal morphology, and juvenile growth in three Malagasy fruit bats'](https://doi.org/10.1093/jmammal/gyac072), out today in the Journal of Mammalogy. 
-<br> 
-<br> 
+
+
+ 
 The Old World Fruit Bat family Pteropodidae is the most endangered group of mammals on earth. Around 35% of the pteropodid species are classified under some category of threat on the IUCN Red List.
-<br> 
-<br> 
+
+
+ 
 Madagascar is home to three endemic fruit bats in the family Pteropodidae: Pteropus rufus, Eidolon dupreanum, and Rousettus madagascariensis. Malagasy fruit bats are facing intense population pressure due to heavy hunting for human consumption and habitat loss from land conversion. Both P. rufus and E. dupreanum are classed as ‘Vulnerable’ on the IUCN Red List and R. madagascariensis as ‘Near Threatened.’ This situation is alarming  because the information concerning the life history traits of the Malagasy bats is scarce, making it challenging to project population viability into the future. 
-<br> 
-<br> 
-<br> 
+
 In our new paper, we quantify life history traits, such as the reproductive period and juvenile growth rate, for these three species. Quantifying this information will be necessary to future efforts to estimate the population viability of these Malagasy fruit bats, as well as to understand their role in maintaining potentially zoonotic viral pathogens.
-<br> 
-<br> 
+
+
+ 
 
 <img src="/assets/img/JMamFig1.png" alt="timeline" class="float-start col-md-12" />
 
-<br> 
-<br> 
+
+
+ 
 In our paper, we quantify the reproductive period for all three Malagasy fruit bats, predicting  gestation spanning from April through September for P. rufus, July through October for E. dupreanum, and August through November for R. madagascariensis in the Moramanga District of central Madagascar. Consistent with previous reports from other frugivores (e.g. lemurs) in Madagascar, we find that all three bats wean their young simultaneously, at the height of the fruit season in late January/early February. We note that we observed the longest period for gestation and lactation for the largest of the three fruit bat species, P.rufus, which is the species most threatened by human hunting. This species also had the most protracted juvenile growth period, so–all in all–the longest period under the most vulnerable life history conditions.
-<br> 
-<br> 
-<br> 
+
 <img src="/assets/img/JMamFig3.png" alt="mass_reside" class="float-start col-md-6" />
 
 We also demonstrated that mass and forearm length are positively correlated for adult fruit bats, but that residuals above and below the regression line can be be used to approximate a bat’s “health”. This mass : forearm residual functions like a ‘body mass index’ for a bat. We showed how this ‘bat BMI’ dips for males during the winter (low fruit) season and increases during the summer (high fruit) season. For females, these data are confounded by the effect of pregnancy - we can see how these residuals increase during the gestation period for female bats, staggered across all three species. Quantification of the duration of this staggered gestation period is important for pinpointing the season when these bats are most vulnerable to human hunting–as well as when humans are most at risk for the spillover of bat-borne viruses, known to be shed intensively under reproductive stress.
-<br> 
-<br> 
+
+
+ 
 In future work, our lab is using hormonal assays of female progesterone and estradiol and male testosterone, to more concretely quantify the limits of these reproductive periods.
-<br />
+
 
 

--- a/_posts/2022-09-07-Novel-Henipavirus.markdown
+++ b/_posts/2022-09-07-Novel-Henipavirus.markdown
@@ -12,30 +12,20 @@ By Katherine McFerrin
 
 <img src="/assets/img/eidolon-dupreanum-duped.jpeg" alt="eidolon" class="float-start col-md-5" />
 
-<br />
+
 We are excited to announce that we have characterized a novel henipavirus, Angavokely Virus (AngV). Our [recent publication in the Journal of Virology](https://journals.asm.org/doi/epub/10.1128/jvi.00921-22) describes the complete coding sequence of AngV from urine samples of the Malagasy fruit bat, Eidolon dupreanum. In prior work AngV had only been identified by serology.
 
-<br/> 
 Henipaviruses are highly pathogenic emerging zoonotic viruses from bat, rodent and shrew reservoirs. AngV may fall within the ranks of other pathogenic henipaviruses including Hendra and Nipah virus following spillover to human hosts. Our work reveals that AngV encodes major proteins associated with pathogenic henipaviruses, notably, the phosphoprotein (P-protein) embedded V and W proteins, which are known to evoke host immune responses. V and W proteins in pathogenic Hendra (HeV), Nipah (NiV), Mojiang (MojV), Daeryong (DARV) and Gamak viruses (GAKV) and Ghanian bat Henipavirus (GhV), but are absent in non-pathogenic Cedar virus (CedV). This suggests that AngV is likely also pathogenic.
 
-<br> 
 <img src="/assets/img/Madera2022Fig3.jpg" alt="pathogenic protein residues" class="float-start col-md-12" />
 
-<br/> 
 AngV is an ancestral bat-borne henipavirus. Using maximum-likelihood and Bayesian phylogenetic analysis we show that AngV is ancestral to the 4 previously described bat-borne henipaviruses (NiV, HeV, CedV, and GhV) but more recently evolved than the rodent and shrew-borne clade of MojV, GAKV, and DARV.  
 
-<br> 
 <img src="/assets/img/Madera2022Fig4.jpg" alt="henipavirus phylogenetic trees" class="float-start col-md-12" />
-
-<br/> 
 
 AngV also provides insights into the greater evolutionary story of henipavirus pathogenesis. AngV adds to the growing number of novel henipaviruses that do not use an ephrin binding cellular entry mechanism. Ephrin type A and B receptor binding allows most Henipaviruses to gain cell entry. Receptors for the MojV clade and AngV, however, remain unknown. AngV lacks the well conserved ephrin-binding residues, F and G proteins, found in other henipaviruses, leaving the door open for novel cell entry mechanisms.
 
-<br> 
 <img src="/assets/img/Madera2022Fig5.jpg" alt="ephrin" class="float-start col-md-12" />
-
-<br/> 
 
 Overall, the discovery and characterization of AngV emphasizes the importance of viral survelliance in Madagascar’s bat populations for circulating henipaviruses. Bats are hunted and consumed as a food source in Madagascar, increasing the chance of disease spillover. Additionally, 9 out of 45 Malagasy bat species can be found across Africa, Asia and/or Europe, which highlights the potential for island hopping to facilitate inter-species viral transmission. Future work to decipher AngV’s cell entry mechanism will allow us to determine the range of hosts for the virus and its zoonotic potential.
 
-<br />

--- a/_posts/2022-09-08-DP2-awarded.markdown
+++ b/_posts/2022-09-08-DP2-awarded.markdown
@@ -9,26 +9,26 @@ tags: [NIH, NIAID, grant] # add tag
 permalink: /news/nih-dp2
 ---
 
-<br> 
 The Brook Lab is excited to announce that we have been awarded an <a href="https://grants.nih.gov/grants/guide/pa-files/PAR-20-259.html">NIH NIAID New Innovators Award (DP2)</a> for 'Crossing scales to predict and prevent bat viruses zoonoses in a Madagascar ecosystem.' This opportunity funds early stage investigators to embark on 'High Risk High Reward' projects outside the scope of more traditional funding mechanisms.
-<br> 
+
 <img src="/assets/img/DP2-NOA.png" alt="DP2-screenshot" class="float-start col-md-12" />
-<br> 
-<br> 
+
+
+ 
  
 Over the next 5 years, we'll be working to (1) decipher the population-level transmission dynamics of potentially zoonotic henipaviruses, filoviruses, and coronaviruses in Madagascar fruit bats, (2) model the within-host energetic constraints that drive seasonal pulses in bat virus shedding, and (3) eradicate potentially zoonotic henipaviruses from Malagasy <i>Eidolon dupreanum</i> (see below) through application of a multivalent henipavirus vaccine. 
 
 <img src="/assets/img/eidolon-dupreanum-duped.jpeg" alt="eidolon" class="float-start col-md-5" />
-<br> 
+
 We'll be collaborating with the lab of <a href="https://sites.google.com/view/aguilarlab/home">Dr. Hector Aguilar Carreno</a> at Cornell University to develop and deploy this vaccine.
-<br>
+
 Stay tuned for all the exciting work ahead!
-<br> 
-<br>
-<br> 
-<br>
-<br> 
-<br>
-<br> 
-<br>
+
+
+ 
+
+
+
+ 
+
 

--- a/_posts/2023-05-16-Biota-award.markdown
+++ b/_posts/2023-05-16-Biota-award.markdown
@@ -9,33 +9,16 @@ tags: [Walder Foundation, Biota Awards, grant] # add tag
 permalink: /news/Biota
 ---
 
-<br> 
 We are excited to announce that Cara is one of five recipients of the <a href="https://www.walderfoundation.org/news/meet-the-2023-biota-awardees">2023 Biota Awards</a> from the Walder Foundation, a Chicago-based non-profit that is here providing funding for conservation-related research.
 
 <img src="/assets/img/Spotlight-BiotaAwards.jpg" alt="Biota" class="center col-md-6" />
 
 Under the funded project, "Harnessing Fruit Bat Conservation to Combat Zoonotic Risk in Madagascar",  Association Ekipa Fanihy is deploying GPS telemetry trackers on Malagasy fruit bats to quantify conncectivity and dispersal, which will be paired with survival data from our longterm field project, to build a metapopulation model of fruit bat conservation status on the island of Madagascar. 
-<br>
+
 
 <img src="/assets/img/pteropus-tag.JPG" alt="tagged pteropus rufus" class="center col-md-5" />
 
 In collaboration with the Malagasy conservation NGO, <a href="https://www.walderfoundation.org/news/meet-the-2023-biota-awardees">Madagasikara Voakajy (MaVoa)</a>, the team will also be piloting some fruit bat habitat restoration interventions, with the aim of improving fruit bat health, reducing virus shedding, and mitigating zoonotic disease risk through conservation. 
-<br> 
 
 Watch an inspiring video of Cara describing her work with the Biota Award--and the Ekipa making it happen--<a href="https://vimeo.com/840916526">here</a>!
-<br> 
-<br>
-<br> 
-<br>
-<br> 
-<br>
-<br> 
-<br>
-<br>
-<br> 
-<br>
-<br> 
-<br>
-<br> 
-<br>
 

--- a/_posts/2023-09-09-Bat-Virulence.markdown
+++ b/_posts/2023-09-09-Bat-Virulence.markdown
@@ -12,14 +12,13 @@ By Cara Brook
 
 
 
-<br />
+
 In a [paper the Brook lab published in PNAS in 2022](https://doi.org/10.1073/pnas.2113628119), we compiled data from the literature to demonstrate that bat-borne viral zoonoses result in higher case fatality rates following spillover to humans than do viruses derived from any other known mammal- or bird host. These highly virulent bat zoonoses include Ebola and Marbugh filoviruses, Hendra and Nipah henipaviruses, and SARS and MERS coronaviruses.  In [our new paper, out this week in PLoS Biology,](https://doi.org/10.1371/journal.pbio.3002268) we offer a mechanistic explanation for the extraordinary virulence of bat virus zoonoses. 
 
 <img src="/assets/img/Brook2023Fig1.png" alt="zoonotic virus virulence" class="center col-md-4" />
 
 
 Our paper presents a theoretical model that seeks to mechanistically recapture the virulence of zoonotic viruses in two key steps: first allowing a virus to evolve over long timescales in its reservoir host, then second, to spillover on shorter timescales in a human host while still maintaining traits (specifically its growth rate) optimized on its original reservoir. 
-<br> 
 
 In our first analysis, we focus on virus adaption in the reservoir host, using a nested, within-host and population-level model and a technique known as 'adaptive dynamics' to derive a mathematical expression that demonstrates how a virus's evolutionarily optimal growth rate--which we call <em>r<sup>*</sup></em>--should reflect the diverse life history traits and physiologies of its reservoir. The optimal <em>r<sup>*</sup></em> balances the benefits of enhanced between-host transmission and the costs of elevated virulence for the host that both result from higher virus growth rates. Faster-reproducing viruses generate higher virus densities in their hosts to facilitate transmission to new hosts--but these high virus densities can also cause direct pathology (disease) or elicit inflammatory immunopathological responses in their hosts. In disease ecology, this paradox is known as the ['transmission-virulence tradeoff'](https://onlinelibrary.wiley.com/doi/full/10.1111/j.1420-9101.2008.01658.x). 
 
@@ -27,7 +26,6 @@ In our first analysis, we focus on virus adaption in the reservoir host, using a
 
 Using life history data from the literature, we make predictions of the evolutionarily optimal virus growth rate (<em>r<sup>*</sup></em>) for 19 different mammalian orders. These <em>r<sup>*</sup></em> predictions vary across different mammal hosts because of variation in the extent to which higher <em>r<sup>*</sup></em> enhances transmission or casuses virulence for diverse host physiologies. We predict the evolution of particularly high <em>r<sup>*</sup></em> values for bat-evolved viruses as a result of a few unique features of bat physiology and immunity that minimize the pathology typically incurred by a high growth rate virus. In particular, several bat species are known to have perpetually primed antiviral immune systems ([via constitutive expression of the antiviral cytokine, IFN-<em>&alpha;</em>](https://www.pnas.org/doi/abs/10.1073/pnas.1518240113)), offering a resistance trait that elevates <em>r<sup>*</sup></em> in our model. In addition, bats also appear to be highly resilient to the immunopathological consequences of virus control by the immune system (chiefly inflammation), providing yet another parameter value in our model ('tolerance of immunopathology') which drives <em>r<sup>*</sup></em> predictions upwards. Critically, we scale this latter parameter as proportional to the residual of predicted lifepsan per body size, such that mammalian orders with longer lifespans than predicted for their body size have high values for the tolerance of immunopathology--and vice versa. As [bats are the longest-lived mammals for their body size known](https://link.springer.com/article/10.1023/B:BGEN.0000038022.65024.d8), we model very high values for immunopathological tolerance in bats, thus elevating <em>r<sup>*</sup></em>.
 
-<br> 
 The link between inflammation, longevity, and tolerance of virus infection rests on a body of recent work out Dr. Linfa Wang's lab at Duke National University of Singapore, which demonstrates how bat longevity results from unique molecular mechanisms that mitigate inflammation--which are thought to have first evolved to dispel the extreme physiological stress that accrues with the highly metabolic activity of powered flight, itself unique to bats among all mammals. See [here](https://www.nature.com/articles/s41564-019-0371-3), [here](https://www.nature.com/articles/srep21722), and [here](https://www.cell.com/cell/pdf/S0092-8674(23)00333-1.pdf) for some relevant examples.
 
 <img src="/assets/img/Brook2023Fig3.jpg" alt="bat vs other" class="center col-md-10" />
@@ -42,13 +40,8 @@ From this, we are able to make predictions of the variation in virulence--here, 
 
 Intriguingly, our model also allows us to make spillover virulence predictions for viruses derived from reservoir orders from which zoonoses have yet to be demonstrated. For example, we predict that viruses evolved in the order Monotremata (echnidna and platypus) should evolved high growth rates likely to cause virulence *in the event that they spilled over to humans*. Importantly, our paper does not consider the *probability* of this zoonosis occurring--and given the large phylogenetic distance between humans and monotremes--such an event would be highly unlikely to begin with. Before getting too excited about these virulence forecasts, it's important to note that we make predictions only at the very coarse, crude level of mammalian order--and base these predictions on extremely limited within-host immunological and physiological data available for comparison across mammals. In reality, we should expect virulence to vary greatly based on species-level differences in the life history and physiological traits modeled here. 
 
-<br> 
 All told, our paper is, essentially, **a robust, quantitative hypothesis meant to stimulate further data collection** at the *in vitro* scale that will facilitate more fine-scaled predictions and empirical tests of those predictions in the future. In [previous work in bat cell tissue culture](https://elifesciences.org/articles/48401), we found some evidence of high virus growth rates evolving in bat immune systems. In upcoming work, we plan to use similar approaches to directly challenge and evaluate the predictions outlined here. 
 
-<br>
+
 For further insights, read [this fantastic primer](https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3002286) summarizing our paper by Samuel Alizon!
 
-
-
-<br/> 
-<br/>

--- a/_posts/2023-10-01-bat-virscan.markdown
+++ b/_posts/2023-10-01-bat-virscan.markdown
@@ -12,7 +12,7 @@ permalink: /news/bat-virscan
 
 by Emily Ruhs
 
-<br />
+
 What if we could apply technology designed for human viral surveillance to other mammals known to host a variety of highly pathogenic viruses? In a recent paper published by the Brook lab in <a href="https://www.frontiersin.org/articles/10.3389/fpubh.2023.1212018/full" target="_blank">Frontiers in Public Health</a>, we do just that!
 
 PhIP-Seq, or Phage-Immunoprecipitation Sequencing, uses recently advanced biomedical technology – broadly, multiplexed genomic sequencing - to identify antiviral antibody-specific binding to peptides displayed on bacteriophages. PhIP-Seq technology has previously been used to comprehensively profile human serum samples for antibodies to the <a href="https://hms.harvard.edu/news/viral-history-drop-blood" target="_blank">VirScan</a> peptidome, a peptide library representing over 200 viruses that constitute the complete known human virome (see <a href="https://www.science.org/doi/10.1126/science.aaa0698" target="_blank">here</a>).

--- a/_posts/2023-11-24-bat-talk-vox.markdown
+++ b/_posts/2023-11-24-bat-talk-vox.markdown
@@ -12,7 +12,7 @@ permalink: /news/bat-talk-vox
 
 
 
-<br />
+
 Cara went on camera with Vox: "Science Explained!" to talk about bat physiology and its consequences for viral infection! Watch the short video here:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Xkuh6JqDiQc?si=3JgDcLuiKRFbHOFl" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-07-12-BatID-2025-at-UChicago.markdown
+++ b/_posts/2025-07-12-BatID-2025-at-UChicago.markdown
@@ -10,25 +10,25 @@ permalink: /news/BatID-2025
 ---
 
 by Cara Brook
-<br>
+
 <img src="/programs/batid-img/BatIDlogo_bw_trimmed.png" alt="BatID" class="img-thumbnail col-md-4" align="center" />
 
-<br>
+
 
 From July 9-11, 2025, the Brook lab hosted the **Fourth International Symposium on the Infectious Diseases of Bats (BatID 2025)** at the University of Chicago. 
-<br>
+
 
 Over 140 people attended, representing 9 countries and 24 states. Plenary Speakers [Dr. Liliana Davalos](https://lmdavalos.github.io) from Stony Brook University, [Dr. Benhur Lee](https://leelabvirus.host/about) from Icahn School of Medicine at Mount Sinai, [Dr. Daniel Streicker](https://streickerlab.com) from the University of Glasgow, [Dr. Simon Anthony](https://anthonylab.vetmed.ucdavis.edu) from UC Davis, and [Dr. Tigga Kingston](https://kingstonlab.org/people/tigga-kingston/) from Texas Tech University led off five fascinating sessions focused, 
 respectively, on *'Bat immunology and within-host dynamics'*, *'Bat pathogen evolution'*, *'Bat pathogen persistence & transmission dynamics'*, *'Bat pathogen discovery'*, and *'Reconciling bat infectious diseases and conservation'*. 
-<br>
+
 
 I owe a huge thanks to co-organizers, [Dr. Arinjay Banerjee](https://banerjeelab.ca) from VIDO, University of Saskatchewan; [Dr. Hannah Frank](https://www.hkfrank.com) from Tulane University; [Dr. Stephanie Seifert](https://labs.wsu.edu/mezap/) from Washington State University; and [Dr. Daniel Becker](https://beckerlab.weebly.com) from the University of Oklahoma. 
-<br>
+
 
 With support from the [NSF IOS Division](https://www.nsf.gov/bio/ios), we were able to fund 17 students to attend with travel awards from all over the world. Please see the [meeting webpage](https://brooklab.org/programs/bat-id-2025) for more information. 
-<br>
+
 
 We look forward to the next BatID, to be held tentatively in the summer of 2027.
-<br>
+
 
 <img src="/assets/img/BatID-2025-group.jpeg" alt="BatID-group" class="img-thumbnail float-start col-md-12" />

--- a/_posts/2025-07-31-Brook-lab-moves-to-Berkeley.markdown
+++ b/_posts/2025-07-31-Brook-lab-moves-to-Berkeley.markdown
@@ -10,20 +10,20 @@ permalink: /news/Brook-lab-at-Cal
 ---
 
 by Cara Brook
-<br>
+
 <img src="/assets/img/UC-Berkeley-Simbolo.jpg" alt="Berkeley" class="img-thumbnail col-md-6" align="center" />
-<br>
+
 
 After four truly wonderful years in the [Department of Ecology and Evolution](https://ecologyandevolution.uchicago.edu) at the [University of Chicago](https://www.uchicago.edu), **the Brook Lab has moved to the [Department of Integrative Biology](https://ib.berkeley.edu) at [UC Berkeley](https://www.berkeley.edu)**.
-<br>
+
 
 While there are many things we will miss about Chicago and our amazing former department, we are excited to have arrived to the Golden State and looking forward to the scientific adventures ahead! 
-<br>
+
 
 Stay tuned for future updates from California!
-<br>
+
 
 <img src="/assets/img/uc-berkeley-landscape.jpg" alt="Berkeley-landscape" class="img-thumbnail col-md-10" align="center" />
 
-<br>
+
 

--- a/join.md
+++ b/join.md
@@ -22,10 +22,7 @@ permalink: /join
 
 <img src="/assets/join/brook_lab_ranomafana.jpeg" alt="ranomafana" class="float-start col-sm-5" />
 
-We are an equal-opportunity group, committed to enacting anti-racist and anti-sexist policies to promote inclusivity in our lab, the biological sciences, and the academy. We believe that black lives matter, women's rights are human rights, and no life is illegal. Applicants from underrepresented backgrounds, ethnicities, genders, sexual orientations, and lifestyles are enthusiastically encouraged to apply to any of the positions outlined below. 
-
-
-<br>
+We are an equal-opportunity group, committed to enacting anti-racist and anti-sexist policies to promote inclusivity in our lab, the biological sciences, and the academy. We believe that black lives matter, women's rights are human rights, and no life is illegal. Applicants from underrepresented backgrounds, ethnicities, genders, sexual orientations, and lifestyles are enthusiastically encouraged to apply to any of the positions outlined below.
 
 
 

--- a/news.md
+++ b/news.md
@@ -15,10 +15,7 @@ permalink: /news
   <div class="post-content" style="float:left; margin-left:2em; max-width:500px;">
     
     <a href="{% if post.link %}{{post.link}}{% else %}{{ post.url| prepend: site.baseurl}}{% endif %}">{{ post.title }}{% if post.link %}<span class="link-arrow"> ↗</span>{% endif %}</a>
-
-    <br/>
-
-    <span class="post-date">{{post.date | date: '%b %d, %Y'}}&nbsp;&nbsp;&nbsp;&nbsp;</span>
+    <div class="post-date">{{post.date | date: '%b %d, %Y'}}&nbsp;&nbsp;&nbsp;&nbsp;</div>
   </div>
 </article>
 

--- a/programs/bat-id-2025-schedule.md
+++ b/programs/bat-id-2025-schedule.md
@@ -17,7 +17,7 @@ _Food and drink available for purchase next door at [Small Cheval](https://small
 Location: [Kent Chemical Laboratory, 1020 E 58th St, Chicago, IL 60637](https://www.google.com/maps/place/1020+E+58th+St,+Chicago,+IL+60637)
 
 **7:00 – 8:00 am**
-Registration open in [Kent Chemical Laboratory Room 120](https://www.google.com/maps/place/1020+E+58th+St,+Chicago,+IL+60637).<br>
+Registration open in [Kent Chemical Laboratory Room 120](https://www.google.com/maps/place/1020+E+58th+St,+Chicago,+IL+60637).\\
 _Coffee and pastries provided._
 
 **8:00 – 8:15 am**  
@@ -65,7 +65,7 @@ Coffee Break and Networking
   “Testing of bat STING orthologs reveals species specific differences in STING functionality”
 
 **12:05 – 1:10 pm**  
-_Boxed lunches will be provided._ <br>
+_Boxed lunches will be provided._\\
 _Feel free to eat in the lecture hall, in the lobby of Kent Chemistry, or out front on the lawn._
 
 ---
@@ -86,7 +86,7 @@ _Feel free to eat in the lecture hall, in the lobby of Kent Chemistry, or out fr
 - **1:45 – 1:50 pm** – *William H. Carr, Medgar Evers College (CUNY)*  
   “MENTOR - Multiplex Embedding of Networks for Team-Based Omics Research analysis identifies potential novel mechanisms for regulating anti-viral immunity in the cave nectar bat”
 - **1:50 – 1:55 pm** – *Kaushal Baid, VIDO, University of Saskatechwan*  
-  *(presented by labmate Victoria Gonzalez)* <br>
+  *(presented by labmate Victoria Gonzalez)*\\
   “Early innate immune response and evolution of a SARS-CoV-2 furin cleavage site inactive variant in bat cells”
 - **1:55 – 2:00 pm** – *Vincent Caval, Institut Pasteur, Paris, France*  
   “Bat antiviral effectors: from comparative transcriptomic analysis to functional studies”
@@ -106,7 +106,7 @@ _Coffee Break and Networking_
 #### Plenary 2
 *(25 min + 5 min Q&A)*
 
-**2:45 – 3:15 pm**  – *Benhur Lee, Icahn School of Medicine at Mount Sinai* <br>
+**2:45 – 3:15 pm**  – *Benhur Lee, Icahn School of Medicine at Mount Sinai*\\
 "Paramyxoviruses from bats: receptor tropism and pathogenesis"
 
 
@@ -155,7 +155,7 @@ Self-organized. See [main website](/programs/bat-id-2025) for recommendations.
 Location: [Kent Chemical Laboratory Room 120](https://www.google.com/maps/place/1020+E+58th+St,+Chicago,+IL+60637)
 
 **7:30 – 8:00 am**
-Late registration open in [Kent Chemical Laboratory Room 120](https://www.google.com/maps/place/1020+E+58th+St,+Chicago,+IL+60637).<br>
+Late registration open in [Kent Chemical Laboratory Room 120](https://www.google.com/maps/place/1020+E+58th+St,+Chicago,+IL+60637).\\
 _Coffee and pastries provided._
 
 
@@ -170,7 +170,7 @@ _Coffee and pastries provided._
 #### Plenary 3
 *(25 min + 5 min Q&A)*
 
-**8:10 – 8:40 am** – *Daniel Streicker, University of Glasgow* <br>
+**8:10 – 8:40 am** – *Daniel Streicker, University of Glasgow*\\
 "Interventions for primary prevention of viral spillover from bats"
 
 #### Short Talks
@@ -215,7 +215,7 @@ _Lunch_
 #### Plenary 4
 *(25 min + 5 min Q&A)*
 
-**12:45 – 1:15 pm**  – *Simon Anthony, University of California-Davis* <br>
+**12:45 – 1:15 pm**  – *Simon Anthony, University of California-Davis*\\
 "Building Predictive Intelligence for Pandemic Prevention"
 
 #### Lightning Talks
@@ -238,7 +238,7 @@ _Lunch_
 #### Plenary 5
 *(25 min + 5 min Q&A)*
 
-**1:40 – 2:10 pm** – *Tigga Kingston, Texas Tech University* <br>
+**1:40 – 2:10 pm** – *Tigga Kingston, Texas Tech University*\\
 "Reconciling bat infectious disease research and conservation: One Health Action Plans for species at the human-bat interface"
 
 #### Short Talks

--- a/programs/bat-id-2025.md
+++ b/programs/bat-id-2025.md
@@ -213,45 +213,45 @@ Register for a **conference ticket [here](https://ti.to/batid-2025/conference-re
 
 
 
-<hr />
+---
 
 <h3>Scientific Program</h3>
 
 Conference registration will open the evening of Wednesday, July 9, 2025. Scientific programming will take place over two full day sessions, including talks, a poster session, and a brainstorming session to delineate future research priorities in the field. 
 
 Scientific talks will be organized into five main scientific themes, after the following basic outline:
-<br>
+
 <h4>Thursday, July 10, 2025</h4>
 
 <h6>Theme I: Bat immunology and within-host dynamics</h6>
 
-Session Chair: <a href="https://brooklab.org">Dr. Cara Brook</a>, UC Berkeley<br />
+Session Chair: <a href="https://brooklab.org">Dr. Cara Brook</a>, UC Berkeley\\
 Plenary Speaker: <a href="https://lmdavalos.github.io">Dr. Liliana Davalos</a>, Stony Brook University
-<br>
+
 <h6>Theme II: Bat pathogen discovery</h6>
 
-Session Chair: <a href="https://labs.wsu.edu/mezap/">Dr. Stephanie Seifert</a>, Washington State University <br />
+Session Chair: <a href="https://labs.wsu.edu/mezap/">Dr. Stephanie Seifert</a>, Washington State University\\
 Plenary Speaker: <a href="https://anthonylab.vetmed.ucdavis.edu">Dr. Simon Anthony</a>, University of California-Davis
-<br>
+
 <h6>Theme III: Bat pathogen evolution</h6>
 
-Session Chair:  <a href="https://banerjeelab.ca">Dr. Arinjay Banerjee</a>, Vaccine and Infectious Diseases Organization, University of Saskatechwan<br />
+Session Chair:  <a href="https://banerjeelab.ca">Dr. Arinjay Banerjee</a>, Vaccine and Infectious Diseases Organization, University of Saskatechwan\\
 Plenary Speaker: <a href="https://leelabvirus.host/about">Dr. Benhur Lee</a>, Icahn School of Medicine at Mount Sinai
-<br>
-<br>
+
+
 <h4>Friday, July 11, 2025</h4>
 
 <h6>Theme IV: Bat pathogen persistence and transmission dynamics</h6>
 
-Session Chair: <a href="http://beckerlab.weebly.com">Dr. Daniel Becker</a>, University of Oklahoma<br />
+Session Chair: <a href="http://beckerlab.weebly.com">Dr. Daniel Becker</a>, University of Oklahoma\\
 Plenary Speaker: <a href="https://streickerlab.com">Dr. Daniel Streicker</a>, University of Glasgow
-<br>
+
 <h6>Theme V: Reconciling bat infectious diseases and conservation</h6>
 
-Session Chair: <a href="https://www.hkfrank.com">Dr. Hannah Frank</a>, Tulane University <br>
+Session Chair: <a href="https://www.hkfrank.com">Dr. Hannah Frank</a>, Tulane University\\
 Plenary Speaker: <a href="https://kingstonlab.org/people/tigga-kingston/">Dr. Tigga Kingston</a>, Texas Tech University
 
-<hr />
+---
 
 Thanks to the support of our <strong>Advisory Committee</strong>:
 <ul>

--- a/publications.md
+++ b/publications.md
@@ -45,7 +45,7 @@ migratorus*) in Chicagoland. In Review. [Link to bioRxiv Preprint](https://doi.o
 -	**Brook CE**, Rozins C, Guth S, and Boots M. Reservoir host immunology and life history shape virulence evolution in zoonotic viruses. 2023. *PLoS Biology*. 21 (9): e3002268. doi: [10.1371/journal.pbio.3002268](https://doi.org/10.1371/journal.pbio.3002268).
       - Profiled in *PLoS Biology* Primer by Samuel Alizon [here](https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3002286).
       - Highlighted in *Newsweek* magazine article by Jess Thompson [here](https://www.newsweek.com/bat-disease-virus-more-deadly-humans-1825340).
-<br/><br/>
+
 - Yek C, **Li Y**, Pacheco AR, Lon C, Duong V, Dussart P, Chea S, **Young KI**, Lay S, Man S, Kimsan S, Huch C, Leang R, Huy R, **Brook CE**, and Manning JE. National dengue surveillance, Cambodia 2002-2020. 2023. *Bulletin of the World Health Organization.* 101: 605-616. doi: [10.2471/BLT.21.287728](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10452936/pdf/BLT.23.289713.pdf)
 
 <h2>2022</h2>
@@ -107,7 +107,7 @@ NAF, Treuer T, and **Brook CE**. Reproduction, seasonal morphology, and juvenile
 
 -	**Brook CE**, **Ranaivoson HC**, Broder CC, Cunningham AA, Héraud JM, Peel AJ, Gibson L, Wood JLN, Metcalf CJE±, and Dobson AP±. 2019. Disentangling serology to elucidate henipa- and filovirus transmission in Madagascar fruit bats. *Journal of Animal Ecology.* . 88 (7): 1001-1016. doi: [10.1111/1365-2656.12985](https://doi.org/10.1111/1365-2656.12985). ±=equal senior contributions.
       - Profiled in JAE blog [here](https://animalecologyinfocus.com/2019/04/16/disentangling-disease-transmission-in-madagascar-fruit-bats/).
-<br/><br/>
+
 - **Brook CE**, Ranaivoson HC, Andriafidison D, Ralisata M, Razafimanahaka J, Héraud JM, Dobson AP, and Metcalf CJE. 2019. Population trends for two Malagasy fruit bats. *Biological Conservation.* 234: 165-171. doi: [10.1016/j.biocon.2019.03.032](https://doi.org/10.1016/j.biocon.2019.03.032).
 
 -	**Ranaivoson HC**, Héraud JM, Goethert HK, Telford SR, Rabetafika L± and **Brook CE**±. Babesial infection in the Madagascan flying fox, *Pteropus rufus* É. Geoffroy, 1803. 2019. *Parasites & Vectors.* 12 (51): 1307101933. doi:  [10.1186/s13071-019-3300-7](https://doi.org/10.1186/s13071-019-3300-7). ±=equal senior contributions


### PR DESCRIPTION
## Summary
- replace HTML `<br>` tags with Markdown line breaks or blank spacing
- swap `<hr>` elements for Markdown `---`
- update schedule/news pages to use block elements instead of `<br>`

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68976328380c8327b27896851c52009b