### PR TITLE
Use Berkeley brand colors for link styling

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,20 +1,28 @@
+:root {
+  --cal-blue: #003262;
+  --cal-blue-light: #3B7EA1; /* lighter offset */
+  --cal-blue-dark: #00254C;  /* darker offset */
+  --cal-gold: #FDB515;
+  --cal-gold-dark: #C4820E;  /* offset for visited links */
+}
+
 a:not(.nav-link):not(.navbar-brand):not(.btn-primary):link {
-  color: #003262;
+  color: var(--cal-blue);
   text-decoration: underline;
 }
 
 a:not(.nav-link):not(.navbar-brand):not(.btn-primary):visited {
-  color: #003262;
+  color: var(--cal-gold-dark);
   text-decoration: underline;
 }
 
 a:not(.nav-link):not(.navbar-brand):not(.btn-primary):hover {
-  color: #3B7EA1;
+  color: var(--cal-gold);
   text-decoration: none;
 }
 
 a:not(.nav-link):not(.navbar-brand):not(.btn-primary):active {
-  color: #00254C;
+  color: var(--cal-blue-dark);
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
- align link colors with UC Berkeley palette by defining Cal blue and gold CSS variables
- switch links to blue with gold hover and dark gold visited states

## Testing
- ❌ `bundle install` (403 "Forbidden" when fetching gems)
- ❌ `bundle exec jekyll build` (bundler: command not found: jekyll)


------
https://chatgpt.com/codex/tasks/task_e_68a551fe0ec083279a0abcb3ae967e9e