### PR TITLE
Standardize permalink URLs to lowercase

### DIFF
--- a/_posts/2024-07-03-ASM-talk.markdown
+++ b/_posts/2024-07-03-ASM-talk.markdown
@@ -6,7 +6,7 @@ description:  (optional)
 img: ASMlogo.jpg
 alt: American Society for Microbiology logo.
 tags: [ASM, conference] # add tag
-permalink: /news/ASM-Microbe-2024
+permalink: /news/asm-microbe-2024
 ---
 
 Cara spoke at ASM Microbe as an invited 'Track Hub' speaker this year, and they wrote this fantastic summary of the talk: <a href="https://asm.org/Articles/2024/July/How-Studying-Bat-Viruses-Prevent-Zoonotic-Disease" target="_blank"> How Studying Bat Viruses Can Help Prevent Zoonotic Disease </a>. 

--- a/_posts/2025-07-12-BatID-2025-at-UChicago.markdown
+++ b/_posts/2025-07-12-BatID-2025-at-UChicago.markdown
@@ -6,7 +6,7 @@ description:  (optional)
 img: BatIDlogo.jpg
 alt: BatID 2025
 tags: [BatID, conference, UChicago] # add tag
-permalink: /news/BatID-2025
+permalink: /news/batid-2025
 ---
 
 by Cara Brook

--- a/_posts/2025-07-31-Brook-lab-moves-to-Berkeley.markdown
+++ b/_posts/2025-07-31-Brook-lab-moves-to-Berkeley.markdown
@@ -6,7 +6,7 @@ description:  (optional)
 img: UCBerkeley-logo.jpg
 alt: UCBerkeley
 tags: [Cal, Berkeley, Brook lab] # add tag
-permalink: /news/Brook-lab-at-Cal
+permalink: /news/brook-lab-at-cal
 ---
 
 by Cara Brook

--- a/_posts/2025-08-12-Cara-wins-Pew-scholarship.markdown
+++ b/_posts/2025-08-12-Cara-wins-Pew-scholarship.markdown
@@ -6,7 +6,7 @@ description:  (optional)
 img: pew-logo.jpg
 alt: Pew
 tags: [Pew, Berkeley, Brook lab] # add tag
-permalink: /news/Pew-scholar
+permalink: /news/pew-scholar
 ---
 
 


### PR DESCRIPTION
## Summary
Standardized all news post permalink URLs to use lowercase formatting for consistency and better URL conventions.

## Changes
- Updated permalink in ASM Microbe 2024 post: `/news/ASM-Microbe-2024` → `/news/asm-microbe-2024`
- Updated permalink in BatID 2025 post: `/news/BatID-2025` → `/news/batid-2025`
- Updated permalink in Brook lab Berkeley post: `/news/Brook-lab-at-Cal` → `/news/brook-lab-at-cal`
- Updated permalink in Pew scholarship post: `/news/Pew-scholar` → `/news/pew-scholar`

## Details
All four news post permalinks have been converted to lowercase to follow standard URL conventions and maintain consistency across the site. This improves URL readability and follows best practices for web URLs.

https://claude.ai/code/session_01UEU8rAyMKAuDXYRpEVsmRQ